### PR TITLE
Fix potential StackOverflowError retracting previous accumulated items

### DIFF
--- a/src/main/clojure/clara/rules.clj
+++ b/src/main/clojure/clara/rules.clj
@@ -164,7 +164,7 @@
 
    If no sources are provided, it will attempt to load rules from the caller's namespace.
 
-   The caller may also specify keyword-style options at the end of the parameters. Currently two
+   The caller may also specify keyword-style options at the end of the parameters. Currently four
    options are supported:
 
    * :fact-type-fn, which must have a value of a function used to determine the logical type of a given

--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -647,7 +647,8 @@
     (for [[bindings element-group] (platform/tuned-group-by :bindings elements)]
       [bindings (map :fact element-group)]))
 
-  (right-activate-reduced [node join-bindings binding-candidates-seq  memory transport listener]
+  (right-activate-reduced [node join-bindings binding-candidates-seq memory transport listener]
+    
     ;; Combine previously reduced items together, join to matching tokens,
     ;; and emit child tokens.
     (doseq [:let [matched-tokens (mem/get-tokens memory node join-bindings)]
@@ -662,7 +663,7 @@
           (retract-accumulated node accum-condition accumulator result-binding token previous-accum-result bindings transport memory listener)))
 
       ;; Combine the newly reduced values with any previous items.
-      (let [combined-candidates (concat previous-candidates candidates)]
+      (let [combined-candidates (into previous-candidates candidates)]
 
         (l/add-accum-reduced! listener node join-bindings combined-candidates bindings)
 


### PR DESCRIPTION
Found a similar issue to what I discovered in both https://github.com/rbrush/clara-rules/pull/59 and https://github.com/rbrush/clara-rules/pull/74.
There is another use of `concat` that is subject to StackOverflowError.  This time it is in the `clara.rules.engine` namespace.  Previously I was only focusing in on the `clara.rules.memory` namespace for issues like this to fix.

I have fixed it the same way that I fixed the previous pull requests listed here.  I have changed the usage of the lazily evaluated `concat` to eagerly evaluated `into`.  Again I do not believe there are any unwanted side effects for going from lazy to eager in this scenario.

In `clara.rules.engine` the special accumulate node type `AccumulateWithJoinFilterNode` had a use of `concat` in the `right-activate-reduced` protocol function implementation.  In this function the previously accumulated "candidates", `previous-candidates`, are tracked in order to retract any tokens that were propagated due to their accumulation.

This issue is only exposed if there are many, nested `previous-candidates`.  It is easy enough to recreate by performing a single insert at a time to trigger this type of accumulate node to have many separate right activations.  Batch insertions will not likely be subject to this issue.  However, I've observed "in the wild" a stack overflow occurring for more obscure reasons due to the truth maintenance ultimately causing the accumulate node to accumulate in a non-batch-style manner.  So this can sneak up even when primarily using batch insertions.
