### PR TITLE
Token retractions may not occur when an accumulator reduces to nil

### DIFF
--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -568,13 +568,13 @@
 
       ;; If the accumulation result was previously calculated, retract it
       ;; from the children.
-      (when previous
+      (when (not= :clara.rules.memory/no-accum-reduced previous)
 
         (doseq [token (mem/get-tokens memory node join-bindings)]
           (retract-accumulated node accum-condition accumulator result-binding token previous bindings transport memory listener)))
 
       ;; Combine the newly reduced values with any previous items.
-      (let [combined (if previous
+      (let [combined (if (not= :clara.rules.memory/no-accum-reduced previous)
                        ((:combine-fn accumulator) previous reduced)
                        reduced)]
 
@@ -604,7 +604,7 @@
             :let [previous (mem/get-accum-reduced memory node join-bindings bindings)]
 
             ;; No need to retract anything if there was no previous item.
-            :when previous
+            :when (not= :clara.rules.memory/no-accum-reduced previous)
 
             ;; Get all of the previously matched tokens so we can retract and re-send them.
             token matched-tokens
@@ -706,9 +706,11 @@
     ;; and emit child tokens.
     (doseq [:let [matched-tokens (mem/get-tokens memory node join-bindings)]
             [bindings candidates] binding-candidates-seq
-            :let [previous-candidates (mem/get-accum-reduced memory node join-bindings bindings)]]
+            :let [previous-candidates (mem/get-accum-reduced memory node join-bindings bindings)
+                  previously-reduced? (not= :clara.rules.memory/no-accum-reduced previous-candidates)
+                  previous-candidates (when previously-reduced? previous-candidates)]]
 
-      (when previous-candidates
+      (when previously-reduced?
 
         (doseq [token (mem/get-tokens memory node join-bindings)
                 :let [previous-accum-result (do-accumulate accumulator join-filter-fn token previous-candidates)]]
@@ -747,7 +749,7 @@
             :let [previous-candidates (mem/get-accum-reduced memory node join-bindings bindings)]
 
             ;; No need to retract anything if there was no previous item.
-            :when previous-candidates
+            :when (not= :clara.rules.memory/no-accum-reduced previous-candidates)
 
             ;; Get all of the previously matched tokens so we can retract and re-send them.
             token matched-tokens

--- a/src/main/clojure/clara/rules/memory.clj
+++ b/src/main/clojure/clara/rules/memory.clj
@@ -10,13 +10,13 @@
   (to-transient [memory]))
 
 (defprotocol IMemoryReader
-  ;; Returns the rulebase associated with the given memor.
+  ;; Returns the rulebase associated with the given memory.
   (get-rulebase [memory])
 
   ;; Returns the elements assoicated with the given node.
   (get-elements [memory node bindings])
 
-  ;; Returns all elements associated with the given node, regarldess of bindings.
+  ;; Returns all elements associated with the given node, regardless of bindings.
   (get-elements-all [memory node])
 
   ;; Returns the tokens associated with the given node.
@@ -157,7 +157,7 @@
     (vals (get beta-memory (:id node) {})))
 
   (get-accum-reduced [memory node join-bindings fact-bindings]
-    (get-in accum-memory [(:id node) join-bindings fact-bindings]))
+    (get-in accum-memory [(:id node) join-bindings fact-bindings] ::no-accum-reduced))
 
   (get-accum-reduced-all [memory node join-bindings]
     (get
@@ -342,7 +342,10 @@
     (flatten (vals (get beta-memory (:id node) {}))))
 
   (get-accum-reduced [memory node join-bindings fact-bindings]
-    (get-in accum-memory [(:id node) join-bindings fact-bindings]))
+    ;; nil is a valid previously reduced value that can be found in the map.
+    ;; Return ::no-accum-reduced instead of nil when there is no previously
+    ;; reduced value in memory.
+    (get-in accum-memory [(:id node) join-bindings fact-bindings] ::no-accum-reduced))
 
   (get-accum-reduced-all [memory node join-bindings]
     (get

--- a/src/main/clojurescript/clara/rules/memory.cljs
+++ b/src/main/clojurescript/clara/rules/memory.cljs
@@ -10,13 +10,13 @@
   (to-transient [memory]))
 
 (defprotocol IMemoryReader
-  ;; Returns the rulebase associated with the given memor.
+  ;; Returns the rulebase associated with the given memory.
   (get-rulebase [memory])
 
   ;; Returns the elements assoicated with the given node.
   (get-elements [memory node bindings])
 
-  ;; Returns all elements associated with the given node, regarldess of bindings.
+  ;; Returns all elements associated with the given node, regardless of bindings.
   (get-elements-all [memory node])
 
   ;; Returns the tokens associated with the given node.
@@ -147,7 +147,10 @@
     (vals (get beta-memory (:id node) {})))
 
   (get-accum-reduced [memory node join-bindings fact-bindings]
-    (get-in accum-memory [(:id node) join-bindings fact-bindings]))
+    ;; nil is a valid previously reduced value that can be found in the map.
+    ;; Return ::no-accum-reduced instead of nil when there is no previously
+    ;; reduced value in memory.
+    (get-in accum-memory [(:id node) join-bindings fact-bindings] ::no-accum-reduced))
 
   (get-accum-reduced-all [memory node join-bindings]
     (get
@@ -335,7 +338,7 @@
     (flatten (vals (get beta-memory (:id node) {}))))
 
   (get-accum-reduced [memory node join-bindings fact-bindings]
-    (get-in accum-memory [(:id node) join-bindings fact-bindings]))
+    (get-in accum-memory [(:id node) join-bindings fact-bindings] ::no-accum-reduced))
 
   (get-accum-reduced-all [memory node join-bindings]
     (get


### PR DESCRIPTION
This is a pull request to deal with what was discussed @ https://github.com/rbrush/clara-rules/issues/78.

- Put together a few test cases showing where previously reduced accumulations that return nil cause retractions of tokens to be missed
- Fixing this centers around disambiguating the cases of no-accum-reduced-ever vs nil-accum-reduced-value when calling clara.rules.memory/get-accum-reduced fn
- Added test case for both AccumulateNode and AccumulateWithJoinFilterNode to verify the issue is fixed