### PR TITLE
Proper truth maintenance when retracting equal facts

### DIFF
--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -759,8 +759,7 @@
 
             ;; Compute the new version with the retracted information.
             :let [previous-result (do-accumulate accumulator join-filter-fn token previous-candidates)
-                  remove-set #{fact}
-                  new-result (do-accumulate accumulator join-filter-fn token (mem/remove-first-of-each remove-set previous-candidates))]]
+                  new-result (do-accumulate accumulator join-filter-fn token (second (mem/remove-first-of-each [fact] previous-candidates)))]]
 
       ;; Add our newly retracted information to our node.
       (mem/add-accum-reduced! memory node join-bindings new-result bindings)

--- a/src/main/clojurescript/clara/rules/memory.cljs
+++ b/src/main/clojurescript/clara/rules/memory.cljs
@@ -89,30 +89,63 @@
   (to-persistent! [memory]))
 
 (defn remove-first-of-each
-  "Remove the first instance of each item in the given set that
-  appears in the collection. This function does so eagerly since
+  "Remove the first instance of each item in the given remove-seq that
+  appears in the collection.  This also tracks which items were found
+  and removed.  Returns a tuple of the form:
+  [items-removed coll-with-items-removed]
+  This function does so eagerly since
   the working memories with large numbers of insertions and retractions
   can cause lazy sequences to become deeply nested."
-  [set coll]
-  (loop [f (first coll)
-         r (rest coll)
-         to-remove set
-         result (transient [])]
+  [remove-seq coll]
+  (cond
 
-    (if f
-      (if (to-remove f)
+    ;; There is nothing to remove.
+    (empty? remove-seq) [[] coll]
 
-        (recur (first r)
-               (rest r)
-               (disj to-remove f)
-               result)
+    ;; Optimization for special case of one item to remove,
+    ;; which occurs frequently.
+    (= 1 (count remove-seq))
 
-        (recur (first r)
-               (rest r)
-               to-remove
-               (conj! result f)))
+    (let [item-to-remove (first remove-seq)
+          [before-it [it & after-it]] (split-with #(not= item-to-remove %) coll)
+          removed (if it [it] [])]
+      [removed (into before-it after-it)])
 
-      (persistent! result))))
+    ;; Otherwise, perform a linear search for items to remove.
+    :else (loop [f (first coll)
+                 r (rest coll)
+                 [remove-seq items-removed result] [remove-seq (transient []) (transient [])]]
+
+            (if f
+              (recur (first r)
+                     (rest r)
+
+                     ;; Determine if f matches any of the items to remove.
+                     (loop [to-remove (first remove-seq)
+                            remove-seq (rest remove-seq)
+                            ;; Remember what is left to remove for later.
+                            left-to-remove (transient [])]
+
+                       ;; Try to find if f matches anything to-remove.
+                       (if to-remove
+                         (if (= to-remove f)
+
+                           ;; Found a match, so the search is done.
+                           [(persistent! (reduce conj! left-to-remove remove-seq))
+                            (conj! items-removed to-remove)
+                            result]
+
+                           ;; Keep searching for a match.
+                           (recur (first remove-seq)
+                                  (rest remove-seq)
+                                  (conj! left-to-remove to-remove)))
+
+                         ;; No matches found.
+                         [(persistent! left-to-remove)
+                          items-removed
+                          (conj! result f)])))
+
+              [(persistent! items-removed) (persistent! result)]))))
 
 (declare ->PersistentLocalMemory)
 
@@ -187,16 +220,15 @@
   (remove-elements! [memory node join-bindings elements]
     (let [binding-element-map (get alpha-memory (:id node) {})
           previous-elements (get binding-element-map join-bindings [])
-          element-set (set elements)
-          filtered-elements (remove-first-of-each element-set previous-elements)]
+          [removed-elements filtered-elements] (remove-first-of-each elements previous-elements)]
 
       (set! alpha-memory
             (assoc! alpha-memory
                     (:id node)
                     (assoc binding-element-map join-bindings filtered-elements)))
 
-      ;; return the removed elements.
-      (s/intersection element-set (set previous-elements))))
+      ;; Return the removed elements.
+      removed-elements))
 
   (add-tokens! [memory node join-bindings tokens]
     (let [binding-token-map (get beta-memory (:id node) {})
@@ -210,16 +242,15 @@
   (remove-tokens! [memory node join-bindings tokens]
     (let [binding-token-map (get beta-memory (:id node) {})
           previous-tokens (get binding-token-map join-bindings [])
-          token-set (set tokens)
-          filtered-tokens (remove-first-of-each token-set previous-tokens)]
+          [removed-tokens filtered-tokens] (remove-first-of-each tokens previous-tokens)]
 
       (set! beta-memory
             (assoc! beta-memory
                     (:id node)
                     (assoc binding-token-map join-bindings filtered-tokens)))
 
-      ;; return the removed elements.
-      (s/intersection token-set (set previous-tokens))))
+      ;; Return the removed tokens.
+      removed-tokens))
 
   (add-accum-reduced! [memory node join-bindings accum-result fact-bindings]
 
@@ -290,8 +321,8 @@
       (set! activation-map
             (assoc activation-map
               activation-group
-              (remove-first-of-each (set to-remove)
-                                    (get activation-map activation-group))))))
+              (second (remove-first-of-each to-remove
+                                            (get activation-map activation-group)))))))
 
   (clear-activations! [memory]
     (set! activation-map (sorted-map-by activation-group-sort-fn)))

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -648,6 +648,45 @@
                  (retract session (->Temperature 10 "MCI"))
                  same-wind-and-temp))))))
 
+(deftest test-retraction-of-equal-elements
+  (let [insert-cold (dsl/parse-rule [[Temperature (= ?temp temperature)]]
+
+                                    ;; Insert 2 colds that have equal
+                                    ;; values to ensure they are both
+                                    ;;retracted
+                                    (insert! (->Cold ?temp)
+                                             (->Cold ?temp)))
+
+        find-cold (dsl/parse-query [] [[?c <- Cold]])
+
+        ;; Each temp should insert 2 colds.
+        session-inserted (-> (mk-session [insert-cold find-cold])
+                             (insert (->Temperature 50 "LAX"))
+                             (insert (->Temperature 50 "MCI"))
+                             fire-rules)
+
+        ;; Retracting one temp should retract both of its
+        ;; logically inserted colds, but leave the others, even though
+        ;; they are equal.
+        session-retracted (-> session-inserted
+                              (retract (->Temperature 50 "MCI"))
+                              fire-rules)]
+
+    (is (= 4 (count (query session-inserted find-cold))))
+
+    (is (= [{:?c (->Cold 50)}
+            {:?c (->Cold 50)}
+            {:?c (->Cold 50)}
+            {:?c (->Cold 50)}]
+           
+           (query session-inserted find-cold)))
+    
+    (is (= 2 (count (query session-retracted find-cold))))
+
+    (is (= [{:?c (->Cold 50)}
+            {:?c (->Cold 50)}]
+           
+           (query session-retracted find-cold)))))
 
 (deftest test-simple-disjunction
   (let [or-query (dsl/parse-query [] [[:or [Temperature (< temperature 20) (= ?t temperature)]


### PR DESCRIPTION
This is a follow up to the issue discussed at https://github.com/rbrush/clara-rules/issues/84.  Facts in working memory with equal values had a potential
to not be properly retracted due to sets being used to group together facts to retract.

The biggest changes here are to the `clara.rules.memory/remove-first-of-each` function.  The former set of items to remove is now an arbitrary seq instead to account for duplicates.
The changes are a bit verbose in order to preserve the efficiency of this function via low-level looping and the use of transients.


----
I noted a few points to consider:

--
(1)

The most common usage of this function is in clara.rules.memory itself and it has the form:

```clj
filtered-elements (remove-first-of-each elements previous-elements)

```

Followed shortly by logic to return the removed elements.

This is doing redundant work and probably (previously at least) would be putting the previous-elements into a set repeatedly.  This could potentially have non-trivial overhead.  Also, to be safe on the consistency of duplicates items being removed and accurately reported, I thought it made sense to shift the responsibility of reporting what was removed to the `remove-first-of-each` function itself.

I have changed this function to return a tuple of `[items-removed coll-with-items-removed]` and I updated the docs.
I realize this makes the return value a little less "clean", but I think it is justified here.

--
(2) 

The return value from functions `remove-elements!` and `remove-tokens!` are a LazySeq with this implementation, where they used to be a set.  I looked around where they are being used at and I do not think that this detail matters.

--
(3)

I noticed that `remove-first-of-each` does not necessarily (not likely actually) preserve the order of the given coll since it rebuilds a seq from two other seq adding to the efficient end, which is the front.  I do not think this is an important detail, but if there I am curious if there is any advantage in preserving the order or not.  I'm thinking that it is not important at all, so I just left it alone for now.

For future reference if it comes up something like this could work:

```clj
(into (vec before-it) after-it)
```
