### PR TITLE
NegationNode should delete removed tokens from node memory on left-retract

### DIFF
--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -436,6 +436,7 @@
       (send-tokens transport memory listener children tokens)))
 
   (left-retract [node join-bindings tokens memory transport listener]
+    (mem/remove-tokens! memory node join-bindings tokens)
     (when (empty? (mem/get-elements memory node join-bindings))
       (retract-tokens transport memory listener children tokens)))
 


### PR DESCRIPTION
I have added a test to clara.test-rules that reveals an issue with how NegationNodes maintain their node memory for retracted tokens in the `left-retract` impl within clara.rules.engine ns.

Basically, when tokens were given to a NegationNode on `left-retract` they were not removed from the nodes memory.  If at a later point a `right-retract` happened for the same NegationNode it could result in tokens being propagated that should have been retracted and removed from the node's memory earlier.

I have added a test to clara.test-rules to show this issue.  It is difficult to demonstrate with a simplified example, so I just used the clara.rules.testfacts First, Second, Third, and Fourth to demonstrate a scenario that would fail.
In this test case, notice that different rule saliences would produce different results.  Of course this shouldn't be the case when using all logically insertions.

If you run the test I have added before this change, you can see that:

```
session-with-results
- passes as a sanity check

session-best-order-salience
- passes with the complex retration flow due to being forced into the "optimal" fire order

session-no-salience
- fails due to the order the activations are fired

session-worst-order-salience
- fails due to the order the activations are fired
```
