### PR TITLE
Allow binding variables to be used in non-sequential literals

### DIFF
--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -182,10 +182,17 @@
        :else
        (list (list 'if exp (cons 'do compiled-rest) nil))))))
 
+(defn flatten-expression
+  "Flattens expression as clojure.core/flatten does, except will flatten
+   anything that is a collection rather than specifically sequential."
+  [expression]
+  (filter (complement coll?)
+          (tree-seq coll? seq expression)))
+
 (defn variables-as-keywords
   "Returns symbols in the given s-expression that start with '?' as keywords"
   [expression]
-  (into #{} (for [item (flatten expression)
+  (into #{} (for [item (flatten-expression expression)
                   :when (and (symbol? item)
                              (= \? (first (name item))))]
               (keyword  item))))
@@ -379,7 +386,7 @@
                                   (not (#{'= '==} (first form)))
                                   (some (fn [sym] (and (symbol? sym)
                                                       (.startsWith (name sym) "?")))
-                                        form))
+                                        (flatten-expression form)))
 
                          (reset! found-complex true))
 
@@ -586,7 +593,7 @@
                                 (not (#{'= '==} (first form)))
                                 (some (fn [sym] (and (symbol? sym)
                                                     (.startsWith (name sym) "?")))
-                                      (flatten form)))
+                                      (flatten-expression form)))
 
                          (doseq [item (rest form)
                                  :when (and (symbol? item)

--- a/src/main/clojure/clara/rules/dsl.clj
+++ b/src/main/clojure/clara/rules/dsl.clj
@@ -184,7 +184,7 @@
 
                            (assoc (meta rhs) :file *file*)))}
 
-        symbols (set (filter symbol? (flatten (concat lhs rhs))))
+        symbols (set (filter symbol? (com/flatten-expression (concat lhs rhs))))
         matching-env (into {} (for [sym (keys env)
                                     :when (symbols sym)
                                     ]
@@ -206,7 +206,7 @@
                                        conditions))
                :params (set params)}
 
-        symbols (set (filter symbol? (flatten lhs)))
+        symbols (set (filter symbol? (com/flatten-expression lhs)))
         matching-env (into {}
                            (for [sym (keys env)
                                  :when (symbols sym)]

--- a/src/main/clojure/clara/rules/engine.clj
+++ b/src/main/clojure/clara/rules/engine.clj
@@ -775,7 +775,7 @@
 (defn variables-as-keywords
   "Returns symbols in the given s-expression that start with '?' as keywords"
   [expression]
-  (into #{} (for [item (flatten expression)
+  (into #{} (for [item (tree-seq coll? seq expression)
                   :when (and (symbol? item)
                              (= \? (first (name item))))]
               (keyword item))))

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -1826,3 +1826,26 @@
           (fire-rules))
 
       (is (= [100 50 0 -50] @salience-rule-output)))))
+
+(deftest test-variable-visibility
+  (let [temps-for-locations (dsl/parse-rule [[:location (= ?loc (:loc this))]
+
+                                             [Temperature
+                                              (= ?temp temperature)
+                                              ;; This can only have one binding right
+                                              ;; now due to work that needs to be done
+                                              ;; still in clara.rules.compiler/extract-from-constraint
+                                              ;; around support multiple bindings in a condition.
+                                              (contains? #{?loc} location)]]
+
+                                            (insert! (->Cold ?temp)))
+        
+        find-cold (dsl/parse-query [] [[?c <- Cold]])
+
+        session (-> (mk-session [temps-for-locations find-cold])
+                    (insert ^{:type :location} {:loc "MCI"})
+                    (insert (->Temperature 10 "MCI"))
+                    fire-rules)]
+
+    (is (= #{{:?c (->Cold 10)}}
+           (set (query session find-cold))))))


### PR DESCRIPTION
As demonstrated in the test case added here to clara.test-rules, variable bindings in rules are overlooked by the rule DSL parsing and rule compilation if the
variables appear in non-sequential Clojure literals.  This would result in compilation errors.

--

The root cause of this issue is the use of  `clojure.core/flatten`.  `flatten` does not behave as often would be expected on non-sequential forms.
A simple demonstration:

```clj

(flatten [1 [2] #{4 [5]} {:a 6}])
;= (1 2 #{4 [5]} {:a 6})

;; Or more simple

(flatten [#{1 2 3}])
;= (#{1 3 2})

;; Or even (arguably) weird

(flatten #{1 2 3})
;= ()

```

I know I've seen people surprised by this in online posts floating around.  If I were to guess why `flatten` behaves the way it does on non-sequentials, it would be
due to the fact that Clojure data often considers a map to be a "atomic unit" when it is found in collections.  So `flatten` allows for maps to be found in nested sequential forms without destroying/flattening them.

--

That's besides the point here.  When processing s-expressions used in rules, we allow for set literals, as well as map literals (although not sure I've seen a map literal used yet).
To remedy the issue, I just replaced the usages of `flatten` with what I called `flatten-expression` in clara.rules.compiler.  This function will flatten anything that is a clojure.core/coll?, which will handle sets and maps as well as sequentials.

I noticed that clara.rules.engine has a function defined called `variables-as-keywords` that duplicates what is in clara.rules.compiler under the same name.  I couldn't use the new `flatten-expression` here due to a circular dependency.  Also, I do not see this function being used though from a search.  I think it may just be left over from a move to clara.rules.compiler earlier perhaps.
So for now, I just copied the impl for `flatten-expression` here.

I could have defined this function in clara.rules.engine instead, but I don't think that is the place I'd expect it to be, considering it doesn't seem to be used in the clara.rules.engine anyways.
