### PR TITLE
Allow explicitly specifying productions in CLJS

### DIFF
--- a/src/test/clojurescript/clara/test_rules_data.clj
+++ b/src/test/clojurescript/clara/test_rules_data.clj
@@ -1,0 +1,23 @@
+(ns clara.test-rules-data)
+
+(def the-rules
+  [{:doc "Rule to determine whether it is indeed cold and windy."
+    :name "clara.test-rules-data/is-cold-and-windy-data"
+    :lhs '[{:type clara.rules.testfacts/Temperature
+            :constraints [(< temperature 20)
+                          (== ?t temperature)]}
+           {:type clara.rules.testfacts/WindSpeed
+            :constraints [(> windspeed 30)
+                          (== ?w windspeed)]}]
+    :rhs '(clara.rules/insert! (clara.rules.testfacts/->ColdAndWindy ?t ?w))}
+
+   {:name "clara.test-rules-data/find-cold-and-windy-data"
+    :lhs '[{:fact-binding :?fact
+            :type clara.rules.testfacts/ColdAndWindy
+            :constraints []}]
+    :params #{}}])
+
+(defn weather-rules
+  "Return some weather rules"
+  []
+  the-rules)


### PR DESCRIPTION
Formerly, Clara/cljs could only load productions from a namespace. This
commit allows `defsession` to take an arbitrary expression, which is
evaluated *in clojure*, and may return a collection of productions that
will be used.

This can be useful in one of two modes:

- As part of a normal CLJS build process using (e.g.) lein-cljsbuild,
  rules can now be read from (for example) data files instead of
  ClojureScript source files.

- It is possible to set up a server which can compile and serve up new
  rule-containing JavaScript files *on demand*, generating sets of rules
  dynamically from (for example) a database.