### PR TITLE
Qualified/aliased/unqualified clojure.core = or == should produce the same rete network

### DIFF
--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -387,9 +387,15 @@
   "Returns true if the given expression does a non-equality unification against a variable,
    indicating it can't be solved by simple unification."
   (let [found-complex (atom false)
+        qualify-when-sym #(when-let [resolved (and (symbol? %)
+                                                   (resolve %))]
+                            (and (var? resolved)
+                                 (symbol (-> resolved meta :ns ns-name name)
+                                         (-> resolved meta :name name))))
         process-form (fn [form]
                        (when (and (list? form)
-                                  (not (#{'= '==} (first form)))
+                                  (not (#{'clojure.core/= 'clojure.core/==}
+                                        (qualify-when-sym (first form))))
                                   (some (fn [sym] (and (symbol? sym)
                                                       (.startsWith (name sym) "?")))
                                         (flatten-expression form)))

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -2369,3 +2369,27 @@
         (fire-rules))
 
     (is (= 42 @rule-output))))
+
+(deftest test-qualified-equals-for-fact-binding
+  (let [get-accum-nodes #(->> %
+                              .rulebase
+                              :beta-roots
+                              first
+                              :children
+                              (filter (partial instance? clara.rules.engine.AccumulateNode)))
+        
+        with-qualified-accum-nodes (get-accum-nodes
+                                    (mk-session [(dsl/parse-query [] [[Temperature (= ?t temperature)]
+
+                                                                      ;; Use fully-qualified = here.
+                                                                      [?c <- (acc/all) :from [Cold (clojure.core/= temperature ?t)]]])]))
+
+        without-qualified-accum-nodes (get-accum-nodes
+                                       (mk-session [(dsl/parse-query [] [[Temperature (= ?t temperature)]
+
+                                                                         ;; Use fully-qualified = here.
+                                                                         [?c <- (acc/all) :from [Cold (= temperature ?t)]]])]))]
+
+    (is (= (count with-qualified-accum-nodes)
+           (count without-qualified-accum-nodes)))))
+


### PR DESCRIPTION
I noticed a difference in the rete network made when using a qualified vs unqualified `=` or `==` in rules for fact bindings.  This was due the clara.rules.compiler only searching for the unqualified variety.

This came up due to generating rules via a macro and using the syntax-quote, which auto-qualifies symbols.  I think this may be a common thing that would be done, so I'm offering this PR to fix the issue.

The solution is to just resolve symbols to vars when possible, then see if they are clojure.core/= or == regardless of being qualified, aliased, or unqualified.


The assumption is that `clojure.core/=` and `==` are the symbols that clara intends to be used for fact bindings.
It would be an interesting case if someone had a definition of their own `=` or `==` in their namespace though.
I think there would be at least one more place in the compiler affected by that.
That's probably unlikely, but the case I found here is more likely.  So I'm just going with this for now.