### PR TITLE
Clara DSL throws NPE for `..` macro symbol

### DIFF
--- a/src/main/clojure/clara/rules.clj
+++ b/src/main/clojure/clara/rules.clj
@@ -151,7 +151,7 @@
      cache. Defaults to Clojures type function.
    * :cache, indicating whether the session creation can be cached, effectively memoizing mk-session.
      Defaults to true. Callers may wish to set this to false when needing to dynamically reload rules.
-   * :activation-group-fn, a function applied to productio structures and returns the group they should be activated with.
+   * :activation-group-fn, a function applied to production structures and returns the group they should be activated with.
      It defaults to checking the :salience property, or 0 if none exists.
    * :activation-group-sort-fn, a comparator function used to sort the values returned by the above :activation-group-fn.
      defaults to >, so rules with a higher salience are executed first.

--- a/src/main/clojure/clara/rules/dsl.clj
+++ b/src/main/clojure/clara/rules/dsl.clj
@@ -116,6 +116,7 @@
         sym)
 
       (if (and (symbol? sym)
+               (not= '.. sym) ; Skip the special .. host interop macro. 
                (.endsWith (name sym) "."))
 
         ;; The . suffix indicates a type constructor, so we qualify the type instead, then

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -2474,3 +2474,14 @@
         (fire-rules))
 
     (is (= -1 @int-value))))
+
+(deftest test-qualified-java-introp
+  (let [find-string-substring (dsl/parse-query []
+                                               [[?s <- String (and (<= 2 (count this))
+                                                                   (.. this (substring 2) toString))]])
+        session (-> (mk-session [find-string-substring])
+                    (insert "abc")
+                    fire-rules)]
+
+    (is (= [{:?s "abc"}]
+           (query session find-string-substring)))))


### PR DESCRIPTION
clara.rules.dsl mistakenly treats the `..` macro symbol as a Java/host constructor call, which causes a NPE to throw.

- Adding a special case to avoid the `..` macro symbol in the constructor call conditional