### PR TITLE
Ensure compiler condition comparison nil-safe

### DIFF
--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -562,6 +562,16 @@
   [left right]
   (cond
 
+   ;; Handle the nil cases first to ensure nil-safety.
+   (and (nil? left) (nil? right))
+   0
+
+   (nil? left)
+   -1
+
+   (nil? right)
+   1
+    
    ;; Ignore functions for our comparison purposes,
    ;; since we won't distinguish rules by them.
    (and (fn? left) (fn? right))

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -2485,3 +2485,18 @@
 
     (is (= [{:?s "abc"}]
            (query session find-string-substring)))))
+
+(deftest test-condition-comparison-nil-safe
+  (let [q (dsl/parse-query []
+                           ;; Make two conditions that are very similar, but differ
+                           ;; where a nil will be compared to something else.
+                           [[(accumulate :reduce-fn (fn [x y] nil)) :from [Temperature]]
+                            [(accumulate :reduce-fn (fn [x y] 10)) :from [Temperature]]])
+        s (mk-session [q])]
+
+    ;; Mostly just ensuring the rulebase was compiled successfully.
+    (is (== 3
+            (-> s
+                .rulebase
+                :id-to-node
+                count)))))


### PR DESCRIPTION
- Comparing arbitrary conditions in clara.rules.compiler (i.e. `gen-compare`) has potentially to throw NPE.  Implemented handling and reproduction case.