### PR TITLE
Ancestors-fn support for clojurescript

### DIFF
--- a/src/main/clojurescript/clara/rules.cljs
+++ b/src/main/clojurescript/clara/rules.cljs
@@ -8,7 +8,7 @@
 (defn- create-get-alphas-fn
   "Returns a function that given a sequence of facts,
   returns a map associating alpha nodes with the facts they accept."
-  [fact-type-fn merged-rules]
+  [fact-type-fn ancestors-fn merged-rules]
 
   ;; We preserve a map of fact types to alpha nodes for efficiency,
   ;; effectively memoizing this operation.
@@ -22,7 +22,7 @@
           [alpha-nodes facts]
 
           ;; The alpha nodes weren't cached for the type, so get them now.
-          (let [ancestors (conj (ancestors fact-type) fact-type)
+          (let [ancestors (conj (ancestors-fn fact-type) fact-type)
 
                 ;; Get all alpha nodes for all ancestors.
                 new-nodes (distinct
@@ -93,11 +93,14 @@
         ;; The fact-type uses Clojure's type function unless overridden.
         fact-type-fn (get options :fact-type-fn type)
 
+        ;; The ancestors for a logical type uses Clojurescript's ancestors function unless overridden.
+        ancestors-fn (get options :ancestors-fn ancestors)
+
         ;; Create a function that groups a sequence of facts by the collection
         ;; of alpha nodes they target.
         ;; We cache an alpha-map for facts of a given type to avoid computing
         ;; them for every fact entered.
-        get-alphas-fn (create-get-alphas-fn fact-type-fn rulebase)
+        get-alphas-fn (create-get-alphas-fn fact-type-fn ancestors-fn rulebase)
 
         ;; Default sort by higher to lower salience.
         activation-group-sort-fn (get options :activation-group-sort-fn >)


### PR DESCRIPTION
The ancestors-fn option isn't handled on clojurescript side.

The fix is very simple changes to create-get-alphas-fn and assemble-session as far as I can see.

PR to follow.