### PR TITLE
RHS captures all s-expressions using implicit `do`

### DIFF
--- a/src/main/clojure/clara/rules/dsl.clj
+++ b/src/main/clojure/clara/rules/dsl.clj
@@ -21,10 +21,11 @@
 (defn split-lhs-rhs
  "Given a rule with the =>, splits the left- and right-hand sides."
  [rule-body]
- (let [[lhs [sep rhs]] (split-with #(not (separator? %))  rule-body)]
+ (let [[lhs [sep & rhs]] (split-with #(not (separator? %)) rule-body)]
 
    {:lhs lhs
-    :rhs rhs}))
+    :rhs (when-not (empty? rhs)
+           (conj rhs 'do))}))
 
 (defn- construct-condition
   "Creates a condition with the given optional result binding when parsing a rule."

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -1409,10 +1409,12 @@
            {:type Temperature :constraints ['(> 6 5)]}]))))
 
 (def simple-defrule-side-effect (atom nil))
+(def other-defrule-side-effect (atom nil))
 
 (defrule test-rule
   [Temperature (< temperature 20)]
   =>
+  (reset! other-defrule-side-effect ?__token__)
   (reset! simple-defrule-side-effect ?__token__))
 
 (deftest test-simple-defrule
@@ -1421,7 +1423,8 @@
 
     (fire-rules session)
 
-    (is (has-fact? @simple-defrule-side-effect (->Temperature 10 "MCI") ))))
+    (is (has-fact? @simple-defrule-side-effect (->Temperature 10 "MCI")))
+    (is (has-fact? @other-defrule-side-effect (->Temperature 10 "MCI")))))
 
 (defquery cold-query
   [:?l]

--- a/src/test/clojurescript/clara/test_rules.cljs
+++ b/src/test/clojurescript/clara/test_rules.cljs
@@ -24,12 +24,8 @@
 (defrule test-rule 
   [Temperature (< temperature 20)]
   =>
+  (reset! other-defrule-side-effect ?__token__)
   (reset! simple-defrule-side-effect ?__token__))
-
-(defrule test-other-rule 
-  [Temperature (< temperature 20)]
-  =>
-  (reset! other-defrule-side-effect ?__token__))
 
 (defquery cold-query
   []
@@ -90,7 +86,8 @@
     
     (fire-rules session)
 
-    (is (has-fact? @simple-defrule-side-effect (->Temperature 10 "MCI")))))
+    (is (has-fact? @simple-defrule-side-effect (->Temperature 10 "MCI")))
+    (is (has-fact? @other-defrule-side-effect (->Temperature 10 "MCI")))))
 
 (deftest test-simple-query
   (let [session (-> my-session


### PR DESCRIPTION
Regarding issue #118 