### PR TITLE
More general clara.rules.schema for s-expression forms

### DIFF
--- a/src/main/clojure/clara/rules/schema.clj
+++ b/src/main/clojure/clara/rules/schema.clj
@@ -22,11 +22,14 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Rule and query structure schema.
 
+(def SExpr
+  (s/pred seq? "s-expression"))
+
 (def FactCondition
   {:type s/Any ;(s/either s/Keyword (s/pred symbol?))
-   :constraints [(s/pred list? "s-expression")]
+   :constraints [SExpr]
    ;; Original constraints preserved for tooling in case a transformation was applied to the condition.
-   (s/optional-key :original-constraints) [(s/pred list? "s-expression")]
+   (s/optional-key :original-constraints) [SExpr]
    (s/optional-key :fact-binding) s/Keyword
    (s/optional-key :args) s/Any
    })
@@ -37,7 +40,7 @@
    (s/optional-key :result-binding) s/Keyword})
 
 (def TestCondition
-  {:constraints [(s/pred list? "s-expression")]})
+  {:constraints [SExpr]})
 
 (def LeafCondition
   (s/conditional

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -2545,3 +2545,31 @@
                 .rulebase
                 :id-to-node
                 count)))))
+
+(deftest test-rule-schema-accepts-seq-forms
+  (let [list-constraint (list `= 'this "abc")
+        cons-constraint (cons `= ['this "abc"])
+        qlist {:lhs [{:fact-binding :?s
+                      :type String
+                      :constraints [list-constraint]}]
+               :params #{}}
+        qcons {:lhs [{:fact-binding :?s
+                      :type String
+                      :constraints [cons-constraint]}]
+               :params #{}}
+
+        ;; Do not allow the session caching since both rules above are
+        ;; equivalent from a clj perspective.
+        qlist-result (-> (mk-session [qlist] :cache false)
+                         (insert "abc")
+                         fire-rules
+                         (query qlist)
+                         set)
+        qcons-result (-> (mk-session [qcons] :cache false)
+                         (insert "abc")
+                         fire-rules
+                         (query qlist)
+                         set)]
+    (is (= #{{:?s "abc"}}
+           qlist-result
+           qcons-result))))


### PR DESCRIPTION
When generating Clara rules a case was encountered where the s-expression predication of `list?` was too restrictive in clara.rules.schema.  This patch generalizes it to `seq?` to allow to accept forms such as a clojure.lang.Cons which can easily creep up in code forms generated with syntax quote in Clojure.

e.g.
```clj
(type `(= 1 2))
;= clojure.lang.Cons

(list? `(= 1 2))
;= false

(seq? `(= 1 2))
;= true
```