### PR TITLE
Allow "munged" Clojure record field names to be used directly in rules

### DIFF
--- a/src/main/clojure/clara/rules/testfacts.clj
+++ b/src/main/clojure/clara/rules/testfacts.clj
@@ -16,3 +16,9 @@
 (defrecord Second [])
 (defrecord Third [])
 (defrecord Fourth [])
+
+;; Record utilizing clj flexible field names.
+(defrecord FlexibleFields [it-works?
+                           a->b
+                           x+y
+                           bang!])


### PR DESCRIPTION
Clojure symbols are more flexible than those allowed by Java in many cases.  For Clojure records, this applies to Java field names.  The Clojure compiler automatically applies a process referred to as "munging" in order to convert flexible Clojure symbols to valid Java field names.
Clara should support reference to field names on Clojure records despite if they are munged on the underlying Java class or not.

The approach taken here was to overhaul the clara.rules.compile/get-field-accessors function that is used specifically for clojure.lang.IRecord subclasses.  Clojure IRecord impls have, for quite a few releases, had a static method that was introduced for "tooling" called `getBasis` [1].  This returns the "unmunged" field names of the Clojure record ordered consistent with the original `deftype` or `defrecord` (etc) form field vector.  This approach should be strictly more flexible than the original implementation of the c.r.c/get-field-accessors function.  

Note that the `getBasis` static method must be invoked through reflection.  The previous approach also used reflection though, so this is not a significant difference.  At compile-time this is an acceptable cost anyways.

Also, note that I've opted to remove the field name metadata on the symbols returned from `getBasis`  because I've ran into trouble before with eval from another context (i.e. namespace) on these symbols if they have unqualified :tag class name symbol type hints.  An alternative approach would be to attempt to qualify these hints, but that is outside the scope of these changes.  The pervious impl for c.r.c/get-field-accessors did not attempt to hint the field name symbols created either, so these changes are consistent with the original.

[1] See "Tool support" -> "Basis access" http://dev.clojure.org/display/design/defrecord+improvements