### PR TITLE
Small test fix for munged field names

### DIFF
--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -2755,17 +2755,18 @@
                              (= ?x+y x+y)
                              (= ?bang! bang!)]])
 
-        s (-> (mk-session [q])
-              (insert ff)
-              fire-rules
-              (query q)
-              set)]
+        res (-> (mk-session [q])
+                (insert ff)
+                fire-rules
+                (query q)
+                set)]
 
-    (is (= #{{:?ff ff}
-             {:?it-works? true}
-             {:?a->b {:a :b}}
-             {:?x+y [:x :y]}
-             {:?bang! :bang!}}))))
+    (is (= #{{:?ff ff
+              :?it-works? true
+              :?a->b {:a :b}
+              :?x+y [:x :y]
+              :?bang! :bang!}}
+           res))))
 
 (deftest test-simple-exists
   (let [has-windspeed (dsl/parse-query [] [[:exists [WindSpeed (= ?location location)]]])


### PR DESCRIPTION
When doing https://github.com/rbrush/clara-rules/pull/121 I wrote a test that mistakenly didn't test what it was supposed to.  This just fixes that test to correctly run the assertion it was intended to.
The enhancement to allow "munged" field names to be used directly in rules still works as expected.
