### PR TITLE
Use seq? instead of list? when looking for non-equality unifications

### DIFF
--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -416,7 +416,7 @@
    indicating it can't be solved by simple unification."
   (let [found-complex (atom false)
         process-form (fn [form]
-                       (when (and (list? form)
+                       (when (and (seq? form)
                                   (not (equality-expression? form))
                                   (some (fn [sym] (and (symbol? sym)
                                                       (.startsWith (name sym) "?")))

--- a/src/main/clojure/clara/rules/dsl.clj
+++ b/src/main/clojure/clara/rules/dsl.clj
@@ -61,7 +61,7 @@
         constraints (vec (if args (drop 2 condition) (rest condition)))]
 
     (when (and (vector? type)
-               (some list? type))
+               (some seq? type))
 
       (throw-dsl-ex (str "Type " type " is a vector and appears to contain expressions. "
                          "Is there an extraneous set of brackets in the condition?")

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -2985,3 +2985,24 @@
         (is (re-find #"test-rule-name" (.getMessage e)))
         (is (= {:?x 10} (:bindings (ex-data e))))
         (is (= "test-rule-name" (:name (ex-data e))))))))
+
+(deftest test-non-list-seq-form-used-for-non-eq-unification
+  (let [non-list-constraint (cons '= '(this (identity ?t)))
+        ;; Sanity check in case Clojure impl details change.
+        _ (is (not (list? non-list-constraint))
+              (str "Ensure test is using non-list seq to expose"
+                   " any `list?` impl specific compiler issues"))
+        q {:lhs [{:type clara.rules.testfacts.Temperature
+                  :constraints []
+                  :fact-binding :?t}
+                 {:type clara.rules.testfacts.Temperature
+                  :constraints [non-list-constraint]}]
+           :params #{}}
+        temp (->Temperature 1 "MCI")
+        res (-> (mk-session [q] :cache false)
+                (insert temp)
+                fire-rules
+                (query q)
+                first)]
+    (is (= {:?t temp}
+           res))))


### PR DESCRIPTION
In `clara.rules.compiler/non-equality-unification?` the criteria to find complex non-equality unifications is too restrictive and can miss "complex" unifications.  The issue is that `list?` is used which specifically only works for clojure.lang.IPersistentList impl's.  Often enough, Clojure s-expressions are other data types that are not covered by `list?`.  It seems that the safest bet for this sort of test is to stick with `seq?`.  This doesn't come up necessarily when rules are created via the Clara DSL macros and functions, however, if other methods of rule generation are used, this is likely to happen.

I have added a test demonstrating how this compiler issue could cause what seems to be valid rules to not compile.  I have also changed the other occurrence of `list?` I found in an error checking scenario of clara.rules.dsl.

Note: This situation is related to what was fixed in https://github.com/rbrush/clara-rules/pull/120.