### PR TITLE
Performance enhancements

### DIFF
--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -2,6 +2,7 @@
   "Forward-chaining rules for Clojure. The primary API is in this namespace."
   (:require [clara.rules.engine :as eng]
             [schema.core :as s]
+            [clara.rules.platform :as platform]
             #?(:cljs [clara.rules.listener :as l])
             #?(:clj [clara.rules.compiler :as com])
             #?(:clj [clara.rules.dsl :as dsl]))
@@ -144,7 +145,7 @@
     ;; effectively memoizing this operation.
     (let [alpha-map (atom {})]
       (fn [facts]
-        (for [[fact-type facts] (group-by fact-type-fn facts)]
+        (for [[fact-type facts] (platform/tuned-group-by fact-type-fn facts)]
 
           (if-let [alpha-nodes (get @alpha-map fact-type)]
 

--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -145,7 +145,7 @@
                          listener)))))
 
   (retract-elements [transport memory listener nodes elements]
-    (doseq  [[bindings element-group] (group-by :bindings elements)
+    (doseq  [[bindings element-group] (platform/tuned-group-by :bindings elements)
              node nodes]
       (right-retract node
                      (select-keys bindings (get-join-keys node))
@@ -155,7 +155,7 @@
                      listener)))
 
   (retract-tokens [transport memory listener nodes tokens]
-    (doseq  [[bindings token-group] (group-by :bindings tokens)
+    (doseq  [[bindings token-group] (platform/tuned-group-by :bindings tokens)
              node nodes]
       (left-retract  node
                      (select-keys bindings (get-join-keys node))

--- a/src/main/clojure/clara/rules/memory.cljc
+++ b/src/main/clojure/clara/rules/memory.cljc
@@ -165,7 +165,7 @@
                                ^:unsynchronized-mutable beta-memory
                                ^:unsynchronized-mutable accum-memory
                                ^:unsynchronized-mutable production-memory
-                               ^:unsynchronized-mutable activation-map]
+                               ^:unsynchronized-mutable #?(:clj ^java.util.NavigableMap activation-map :cljs activation-map)]
 
   IMemoryReader
   (get-rulebase [memory] rulebase)
@@ -316,7 +316,7 @@
       (pop-activation!
         [memory]
         (when (not (.isEmpty activation-map))
-          (let [^java.util.Map$Entry entry (.firstEntry activation-map)
+          (let [entry (.firstEntry activation-map)
                 key (.getKey entry)
                 value (.getValue entry)
                 remaining (rest value)]
@@ -342,7 +342,7 @@
       (next-activation-group
         [memory]
         (when (not (.isEmpty activation-map))
-          (let [^java.util.Map$Entry entry (.firstEntry activation-map)]
+          (let [entry (.firstEntry activation-map)]
             (.getKey entry))))
       :cljs
       (next-activation-group


### PR DESCRIPTION
I was looking at performance across a few fairly large rulebases and large dataset I had to work with.  While profiling, I noticed a few easy to spot performance time sinks coming out of the reflection warnings in clara.rules.memory.  I also saw a few places where using `clara.rules.platform/tuned-group-by` would be preferable than Clojure's built-in `group-by`.