### PR TITLE
Batch right-retracts in accumulate nodes

### DIFF
--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -800,14 +800,15 @@
   (right-retract [node join-bindings elements memory transport listener]
 
     (doseq [:let [matched-tokens (mem/get-tokens memory node join-bindings)]
-            {:keys [fact bindings] :as element} elements
+            [bindings elements] (platform/tuned-group-by :bindings elements)
             :let [previous (mem/get-accum-reduced memory node join-bindings bindings)]
 
             ;; No need to retract anything if there was no previous item.
             :when (not= :clara.rules.memory/no-accum-reduced previous)
 
             ;; Compute the new version with the retracted information.
-            :let [retracted ((:retract-fn accumulator) previous fact)]]
+            :let [facts (mapv :fact elements)
+                  retracted (r/reduce (:retract-fn accumulator) previous facts)]]
 
       ;; Add our newly retracted information to our node.
       (mem/add-accum-reduced! memory node join-bindings retracted bindings)
@@ -978,14 +979,15 @@
   (right-retract [node join-bindings elements memory transport listener]
 
     (doseq [:let [matched-tokens (mem/get-tokens memory node join-bindings)]
-            {:keys [fact bindings] :as element} elements
+            [bindings elements] (platform/tuned-group-by :bindings elements)
             :let [previous-candidates (mem/get-accum-reduced memory node join-bindings bindings)]
 
             ;; No need to retract anything if there was no previous item.
             :when (not= :clara.rules.memory/no-accum-reduced previous-candidates)
 
-            :let [new-candidates (second (mem/remove-first-of-each [fact] previous-candidates))]]
-
+            :let [facts (mapv :fact elements)
+                  new-candidates (second (mem/remove-first-of-each facts previous-candidates))]]
+      
       ;; Add the new candidates to our node.
       (mem/add-accum-reduced! memory node join-bindings new-candidates bindings)
 


### PR DESCRIPTION
I have identified what looks like a quick and easy performance optimization for Clara accumulator node retraction logic.
As implemented, I think that `clara.rules.engine/right-retract`s are not retracting facts in a batch/collection-based style.  This is in contrast to how the `c.r.e/right-activate` does perform accumulation logic in batches.

I'd like to have stronger benchmarks for some future changes, but I think for this one I can make a pretty brute-force example to demonstrate the speed to be gained.

Before change:

```clj
(let [r1 (dsl/parse-rule [[?ts <- (acc/all) :from [Temperature]]]
                         (insert! (->TemperatureHistory ?ts)))
      r2 (dsl/parse-rule [[TemperatureHistory (= ?ts temperatures)]]
                         (insert-all! (map (comp ->Cold :temperature) ?ts)))
      q (dsl/parse-query []
                         [[?cs <- (acc/all) :from [Cold]]])

      n 10000
      temps (vec (for [i (range n)]
                   (->Temperature i "MCI")))

      s (-> (mk-session [r1 r2 q])
            (insert-all temps)
            fire-rules)]
  (is (= n
         (-> (query s q) set first :?cs count)))

  (time (fire-rules (apply retract s temps))))



"Elapsed time: 46181.982236 msecs"
#object[clara.rules.engine.LocalSession 0x3adee9be "clara.rules.engine.LocalSession@3adee9be"]
```

Same thing after:

```clj
"Elapsed time: 24143.068935 msecs"
#object[clara.rules.engine.LocalSession 0x67c327b9 "clara.rules.engine.LocalSession@67c327b9"]
```

So this trimmed 20 seconds off the time.  There are some other notable spots where time is spent now when I look at the before vs after profiling results, but I'd like to address each concern separately where appropriate.

I have ran these several times repeatedly in the same process as well to ensure there was some "JVM warmup" done.  The results seem consistent.

The PR here is very simple.  It just ensures that we do retraction logic in batch for clara.rules.engine.AccumulateNode and c.r.e.AccumulateWithJoinNode.
