### PR TITLE
Remove potential reflection

### DIFF
--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -262,9 +262,19 @@
 (defn- add-meta
   "Helper function to add metadata."
   [fact-symbol fact-type]
-  (if (class? fact-type)
-    (vary-meta fact-symbol assoc :tag (symbol (.getName ^Class fact-type)))
-    fact-symbol))
+  (let [fact-type (if (symbol? fact-type)
+                    (try
+                      (resolve fact-type)
+                      (catch Exception e
+                        ;; We shouldn't have to worry about exceptions being thrown here according
+                        ;; to `resolve`s docs.
+                        ;; However, due to http://dev.clojure.org/jira/browse/CLJ-1403 being open
+                        ;; still, it is safer to catch any exceptions thrown.
+                        fact-type))
+                    fact-type)]
+    (if (class? fact-type)
+      (vary-meta fact-symbol assoc :tag (symbol (.getName ^Class fact-type)))
+      fact-symbol)))
 
 (defn compile-condition
   "Returns a function definition that can be used in alpha nodes to test the condition."


### PR DESCRIPTION
I have noticed some new reflection warnings creeping up from the work done with https://github.com/rbrush/clara-rules/issues/149 where `clara.rules.compiler/extract-negations` was added.

The issue is that Clara rules conditions schema for clara.rules.schema.FactType `:type` is open to be more than just Class instances https://github.com/rbrush/clara-rules/blob/0.9.2/src/main/clojure/clara/rules/schema.clj#L29 .  The compiler appropriately allows the type of `:type` to not be important.  However, when the type is a Class instance, it is used as `:tag` metadata so that Clojure doesn't need to do reflection when accessing fields of objects in rule conditions.

When `extract-negations` was added, it used a Symbol rather than a Class for the `:type` of the condition.  This could just be switched to a Class, but that only fixes this issue.  I think a more general approach is to just extend `c.r.c/add-meta` to try to resolve Symbols to a Class, and if they resolve to one, use that as `:tag` metadata.  
this is consistent with Clojure in many ways, since Clojure's compiler often blurs the line of whether `:tag`-type metadata is an actual Class instance, or still a Symbol that resolves to a Class.

With this PR applied, all reflection warnings I saw related to this went away.  I always build Clara with reflection warnings on.  Also, my projects that use Clara are no longer seeing the reflection warnings coming from the extracted negations anymore.