### PR TITLE
Add grouping-by accumulator

### DIFF
--- a/src/main/clojure/clara/rules/accumulators.cljc
+++ b/src/main/clojure/clara/rules/accumulators.cljc
@@ -107,6 +107,27 @@
        :combine-fn wrapped-combine-fn
        :convert-return-fn wrapped-convert-return-fn}))))
 
+(let [grouping-fn (fnil conj [])
+      combine-fn (fn [a b]
+                   (merge-with (comp vec into) a b))]
+  (defn grouping-by
+    "Return a generic grouping accumulator. Behaves like clojure.core/group-by.
+
+  * `field` - required - The field of a fact to group by.
+  * `convert-return-fn` - optional - Converts the resulting grouped
+  data. Defaults to clojure.core/identity."
+    ([field]
+     (grouping-by field identity))
+    ([field convert-return-fn]
+     {:pre [(ifn? convert-return-fn)]}
+     (reduce-to-accum
+      (fn [m x]
+        (let [v (field x)]
+          (update m v grouping-fn x)))
+      {}
+      convert-return-fn
+      combine-fn))))
+
 (defn- comparison-based
   "Creates a comparison-based result such as min or max"
   [field comparator returns-fact supports-retract]


### PR DESCRIPTION
This PR adds a `grouping-by` accumulator.

Basic example:

```clojure
(defrecord Foo [num])

(def grouping-accum (clara.rules.accumulators/grouping-by :num))

(defquery q:grouped-foos []
  [?grouped-foos <- grouping-accum :from [Foo]])

(-> (mk-session [q:grouped-foos])
    (insert-all [(->Foo 1)
                 (->Foo 2)
                 (->Foo 3)])
    (query q:grouped-foos))

;; ({:?grouped-foos {1 [#clara.rules.testfacts.Foo{:num 1}], 2 [#clara.rules.testfacts.Foo{:num 2}], 3 [#clara.rules.testfacts.Foo{:num 3}]}})
```

An example of using the optional `convert-return-fn` argument:

```clojure
(defrecord Foo [num])

(defn max-foos
  [m]
  (if (seq m)
    (->> (keys m)
         (map #(Long/parseLong %))
         (apply max)
         (str)
         (get m))
    m))

(def grouping-accum (clara.rules.accumulators/grouping-by :num max-foos))

(defquery q:max-foos []
  [?max-foos <- grouping-accum :from [Foo]])

(-> (mk-session [q:max-foos])
    (insert-all [(->Foo "10")
                 (->Foo "20")
                 (->Foo "30")
                 (->Foo "30")
                 (->Foo "45")])
    (retract (->Foo "45"))
    (query q:max-foos))

;; ({:?max-foos [#clara.rules.testfacts.Foo{:num "30"} #clara.rules.testfacts.Foo{:num "30"}]})
```
