### PR TITLE
providing compile context during compilation (take 2)

### DIFF
--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1084,7 +1084,8 @@
         create-id-fn (fn [] (swap! id-counter inc))]
 
     (reduce (fn [beta-graph production]
-              (add-production production beta-graph create-id-fn))
+              (binding [*compile-ctx* {:production production}]
+                (add-production production beta-graph create-id-fn)))
 
             empty-beta-graph
             productions)))

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -3388,3 +3388,13 @@
     (is (= distinct-sessions
            [s1 s2 s5 s6 s8]))
   (reset! @#'com/session-cache original-cache)))
+
+(deftest test-try-eval-failures-includes-compile-ctx
+  (let [q1 (dsl/parse-query [] [[:not [Temperature (= ?t temperature)]]])
+        q2 (dsl/parse-query [] [[First (= ?b bogus)]])]
+
+    (assert-ex-data {:production q1}
+                    (mk-session [q1]))
+
+    (assert-ex-data {:condition (-> q2 :lhs first)}
+                    (mk-session [q2]))))


### PR DESCRIPTION
A few error messages I have seen during testing newer changes in the current snapshot have lost one part of the changes from https://github.com/rbrush/clara-rules/pull/156.

The `:production` is not showing up when `clara.rules.compiler/try-eval` fails like it was intended to.  This was lost in the clara.rules.compiler rework done with https://github.com/rbrush/clara-rules/commit/f9537c7540e1a8baa5cf07f0f88b0116125d31f9.
I have added it back again and added a few tests to attempt to validate that this isn't overlooked again in the future as easily.

