### PR TITLE
No auto qualifying vars in rule RHS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /lib
 /classes
 /checkouts
+/resources/public/js/*
 pom.xml
 pom.xml.asc
 *.jar
@@ -10,4 +11,5 @@ pom.xml.asc
 .lein-failures
 .lein-plugins
 .lein-repl-history
+figwheel_server.log
 *.*~

--- a/project.clj
+++ b/project.clj
@@ -6,27 +6,34 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.170" :scope "provided"]
                  [prismatic/schema "1.0.1"]]
-  :plugins [[lein-codox "0.9.0"]
-            [lein-javadoc "0.2.0"]
-            [lein-cljsbuild "1.1.1"]]
+  :plugins [[lein-codox "0.9.0" :exclusions [org.clojure/clojure]]
+            [lein-javadoc "0.2.0" :exclusions [org.clojure/clojure]]
+            [lein-cljsbuild "1.1.3" :exclusions [org.clojure/clojure]]
+            [lein-figwheel "0.5.2" :exclusions [org.clojure/clojure]]]
   :codox {:namespaces [clara.rules clara.rules.dsl clara.rules.accumulators
                        clara.rules.listener clara.rules.durability
                        clara.tools.inspect clara.tools.tracing]
           :metadata {:doc/format :markdown}}
   :javadoc-opts {:package-names "clara.rules"}
-
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure" "src/test/common"]
   :java-source-paths ["src/main/java"]
   :javac-options ["-target" "1.6" "-source" "1.6"]
+  :clean-targets ^{:protect false} ["resources/public/js" "target"]
   :hooks [leiningen.cljsbuild]
   :cljsbuild {:builds [;; Simple mode compilation for tests.
-                       {:source-paths ["src/test/clojurescript" "src/test/common"]
-                        :compiler {:output-to "target/js/simple.js"
-                                   :optimizations :whitespace}}
+                       {:id "simple"
+                        :source-paths ["src/test/clojurescript" "src/test/common"]
+                        :figwheel true
+                        :compiler {:main "clara.test"
+                                   :output-to "resources/public/js/simple.js"
+                                   :output-dir "resources/public/js/out"
+                                   :asset-path "js/out"
+                                   :optimizations :none}}
 
                        ;; Advanced mode compilation for tests.
-                       {:source-paths ["src/test/clojurescript"]
+                       {:id "advanced"
+                        :source-paths ["src/test/clojurescript"]
                         :compiler {:output-to "target/js/advanced.js"
                                    :optimizations :advanced}}]
 
@@ -37,9 +44,8 @@
                               "phantom-advanced" ["phantomjs"
                                                   "src/test/js/runner.js"
                                                   "src/test/html/advanced.html"]}}
-
   :scm {:name "git"
-          :url "https://github.com/rbrush/clara-rules"}
+        :url "https://github.com/rbrush/clara-rules"}
   :pom-addition [:developers [:developer
                               [:id "rbrush"]
                               [:name "Ryan Brush"]

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">    
+    <!-- <link href="css/style.css" rel="stylesheet" type="text/css"> -->
+  </head>
+  <body>
+    <div id="app">
+      <h2>Figwheel template</h2>
+      <p>Checkout your developer console.</p>
+    </div>
+    <script src="js/simple.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -1232,9 +1232,10 @@
       (eng/->ProductionNode
        id
        production
-       (binding [*file* (:file (meta (:rhs production)))
-                 *compile-ctx* {:production production
-                                :msg "compiling production node"}]
+       (with-bindings (cond-> {#'*file* (-> production :rhs meta :file)
+                               #'*compile-ctx* {:production production
+                                                :msg "compiling production node"}}
+                        (:ns-name production) (assoc #'*ns* (the-ns (:ns-name production))))
          (compile-expr id
                        (with-meta (compile-action (:bindings beta-node)
                                                   (:rhs production)

--- a/src/main/clojure/clara/rules/schema.clj
+++ b/src/main/clojure/clara/rules/schema.clj
@@ -60,7 +60,11 @@
    map? LeafCondition))
 
 (def Rule
-  {(s/optional-key :name) s/Str
+  {;; :ns-name is currently used to eval the :rhs form of a rule in the same
+   ;; context that it was originally defined in.  It is optional and only used
+   ;; when given.  It may be used for other purposes in the future.
+   (s/optional-key :ns-name) s/Symbol
+   (s/optional-key :name) s/Str
    (s/optional-key :doc) s/Str
    (s/optional-key :props) {s/Keyword s/Any}
    (s/optional-key :env) {s/Keyword s/Any}

--- a/src/test/clojurescript/clara/test_rules_data.clj
+++ b/src/test/clojurescript/clara/test_rules_data.clj
@@ -1,4 +1,6 @@
-(ns clara.test-rules-data)
+(ns clara.test-rules-data
+  (:require [clara.rules]
+            [clara.rules.testfacts]))
 
 (def the-rules
   [{:doc "Rule to determine whether it is indeed cold and windy."


### PR DESCRIPTION
This address the issue from https://github.com/rbrush/clara-rules/issues/178.

I didn't deal with issues of locals shadowing in LHS rule conditions right now.  They are theoretically possible, but probably much less common due to the fact that I'd not expect it to be "good practice" to do things like let-bindings in the constraints of LHS conditions.  We can address this later if needed, but qualified symbols do have some value in our static, "semantic" analysis done on LHS conditions within the Clara compiler.

If anyone is generated rules without using the clara.rules.dsl (we have cases) then the contract has not changed.  The generated rule RHS would have had to use "manually" qualified vars before and still will now.  The only addition is that the generated rules could also choose to set the `:ns-name` instead of qualifying the vars if they wanted the RHS form to be eval'ed in a specific `*ns*` valued binding.

I also added some fairly primitive support to use figwheel in Clara.  This looks to be the state-of-the-art in running REPLs in CLJS and it works pretty easily right out-of-the-box.  I'd still like to get it working to launch an nREPL server, but I'm leaving that as a task for another time.  I stumbled across CLJS due to the changes at clara.macros/gen-beta-network where I wanted to preserve the expected CLJS behavior around eval of the RHS.