### PR TITLE
Do not include dev (figwheel) resources built jar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
           :metadata {:doc/format :markdown}}
   :javadoc-opts {:package-names "clara.rules"}
   :source-paths ["src/main/clojure"]
+  :resource-paths []
   :test-paths ["src/test/clojure" "src/test/common"]
   :java-source-paths ["src/main/java"]
   :javac-options ["-target" "1.6" "-source" "1.6"]


### PR DESCRIPTION
The figwheel support added in https://github.com/rbrush/clara-rules/commit/3f74817e736687fad33f37dd6f646d4e4b2a5d96 are being included in the clara-rules jar.  They shouldn't be since they are only useful during dev time.

I missed this previously.  The quick fix for this right now is to just use `:resource-paths []` since we do not have any real resources that need included in the jar for now.  In the future if we do, we can use a different resource path - I'd imagine it would be "src/main/resources" to follow the rest the directory structure pattern we are using.  We could also move the figwheel stuff where it is excluded if the "resources" path is still included.