### PR TITLE
Fix ClojureScript test build for whitespace optimizations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
   :clean-targets ^{:protect false} ["resources/public/js" "target"]
   :hooks [leiningen.cljsbuild]
   :cljsbuild {:builds [;; Simple mode compilation for tests.
-                       {:id "simple"
+                       {:id "figwheel"
                         :source-paths ["src/test/clojurescript" "src/test/common"]
                         :figwheel true
                         :compiler {:main "clara.test"
@@ -32,9 +32,14 @@
                                    :asset-path "js/out"
                                    :optimizations :none}}
 
+                       {:id "simple"
+                        :source-paths ["src/test/clojurescript" "src/test/common"]
+                        :compiler {:output-to "target/js/simple.js"
+                                   :optimizations :whitespace}}
+
                        ;; Advanced mode compilation for tests.
                        {:id "advanced"
-                        :source-paths ["src/test/clojurescript"]
+                        :source-paths ["src/test/clojurescript" "src/test/common"]
                         :compiler {:output-to "target/js/advanced.js"
                                    :optimizations :advanced}}]
 

--- a/src/test/clojurescript/clara/test.cljs
+++ b/src/test/clojurescript/clara/test.cljs
@@ -1,6 +1,7 @@
 (ns clara.test
   (:require-macros [cljs.test :as test])
   (:require [clara.test-rules]
+            [cljs.test]
             [clara.test-common]))
 
 (enable-console-print!)


### PR DESCRIPTION
It looks like [1] changed the "simple" build for the ClojureScript tests and moved the file that this build depends on. [2] The build is now failing [3] when [4] fails to resolve the JavaScript variable clara.test.run [5].

This PR adds back the original simple build and moves the Figwheel build into a new ClojureScript build.  It also adds the source directory "src/test/common" to the advanced build source paths
to be the same as the simple build.  Lastly, if my understanding of the way ClojureScript
namespace forms is correct (which it might not be) it looks like [6] is relying on 
its transitive dependencies to require the ClojureScript version of cljs.test 
(as opposed to the .cljc version with macros). I went ahead and added an explicit require for the
cljs.test namespace there.

Ideally the ClojureScript tests failing like this would cause the main build to actually
fail instead of just printing failure messages to standard out.  I'll log a separate issue
for that; I don't see immediately see a quick fix for that.

1. https://github.com/rbrush/clara-rules/pull/179/files
2. https://github.com/rbrush/clara-rules/blob/0.11.1/src/test/html/simple.html#L3
3. https://travis-ci.org/rbrush/clara-rules/builds/125594217
Particularly
````
Running ClojureScript test: phantom-simple
ReferenceError: Can't find variable: clara
  phantomjs://webpage.evaluate():2
  phantomjs://webpage.evaluate():3
  phantomjs://webpage.evaluate():3
````
4. https://github.com/rbrush/clara-rules/blob/0.11.1/src/test/js/runner.js#L24
5. https://github.com/rbrush/clara-rules/blob/0.11.1/src/test/clojurescript/clara/test.cljs#L13
6. https://github.com/rbrush/clara-rules/blob/0.11.1/src/test/clojurescript/clara/test.cljs#L8