### PR TITLE
Mutable JVM colls in local memory for efficiency

### DIFF
--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -152,26 +152,34 @@
 (def ^:dynamic *rule-context* nil)
 
 (defn- flush-updates
-  "Flush pending updates in the current session. Returns true if there were some items to flush,
-  false otherwise"
+  "Flush all pending updates in the current session. Returns true if there were
+   some items to flush, false otherwise"
   [current-session]
+  (letfn [(flush-all [current-session flushed-items?]
+            (let [{:keys [rulebase transient-memory transport insertions get-alphas-fn listener]} current-session
+                  pending-updates @(:pending-updates current-session)]
 
-  (let [{:keys [rulebase transient-memory transport insertions get-alphas-fn listener]} current-session
-        pending-updates @(:pending-updates current-session)]
+              ;; Remove the facts here so they are re-inserted if we flush recursively.
+              (reset! (:pending-updates current-session) [])
 
-    ;; Remove the facts here so they are re-inserted if we flush recursively.
-    (reset! (:pending-updates current-session) [])
+              (if (empty? pending-updates)
+                flushed-items?
+                (do
+                  (doseq [partition (partition-by :type pending-updates)
+                          :let [facts (mapcat :facts partition)]
+                          [alpha-roots fact-group] (get-alphas-fn facts)
+                          root alpha-roots]
 
-    (doseq [partition (partition-by :type pending-updates)
-            :let [facts (mapcat :facts partition)]
-            [alpha-roots fact-group] (get-alphas-fn facts)
-            root alpha-roots]
+                    (if (= :insert (:type (first partition)))
+                      (alpha-activate root fact-group transient-memory transport listener)
+                      (alpha-retract root fact-group transient-memory transport listener)))
 
-      (if (= :insert (:type (first partition)))
-        (alpha-activate root fact-group transient-memory transport listener)
-        (alpha-retract root fact-group transient-memory transport listener)))
+                  ;; There may be new :pending-updates due to the flush just
+                  ;; made.  So keep flushing until there are none left.  Items
+                  ;; were flushed though, so flush-items? is now true.
+                  (flush-all current-session true)))))]
 
-    (not (empty? pending-updates))))
+    (flush-all current-session false)))
 
 (defn insert-facts!
   "Place facts in a stateful cache to be inserted into the session 
@@ -267,36 +275,31 @@
       (mem/remove-activations! memory production activations))
 
     ;; Retract any insertions that occurred due to the retracted token.
-    (let [token-insertion-map (mem/remove-insertions! memory node tokens)
-          insertions (apply concat (vals token-insertion-map))]
+    (let [token-insertion-map (mem/remove-insertions! memory node tokens)]
 
-      ;; If there is current session with rules firing, add these items to the queue
-      ;; to be retracted so they occur in the same order as facts being inserted.
-      (if *current-session*
+      (when-let [insertions (seq (apply concat (vals token-insertion-map)))]
+        ;; If there is current session with rules firing, add these items to the queue
+        ;; to be retracted so they occur in the same order as facts being inserted.
+        (if *current-session*
+          ;; Retract facts that have become untrue, unless they became untrue
+          ;; because of an activation of the current rule that is :no-loop
+          (when (or (not (get-in production [:props :no-loop]))
+                    (not (= production (get-in *rule-context* [:node :production]))))
+            (do
+              ;; Notify the listener of logical retractions.
+              (doseq [[token token-insertions] token-insertion-map]
+                (l/retract-facts-logical! listener node token token-insertions))
+              (retract-facts! insertions)))
 
-        ;; Retract facts that have become untrue, unless they became untrue
-        ;; because of an activation of the current rule that is :no-loop
-        (when (or (not (get-in production [:props :no-loop]))
-                  (not (= production (get-in *rule-context* [:node :production]))))
-
-          (do
+          ;; The retraction is occuring outside of a rule-firing phase,
+          ;; so simply retract them as an external caller would.
+          (let [get-alphas-fn (mem/get-alphas-fn memory)]
             ;; Notify the listener of logical retractions.
             (doseq [[token token-insertions] token-insertion-map]
               (l/retract-facts-logical! listener node token token-insertions))
-
-            (retract-facts! insertions)))
-
-        ;; The retraction is occuring outside of a rule-firing phase,
-        ;; so simply retract them as an external caller would.
-        (let [get-alphas-fn (mem/get-alphas-fn memory)]
-
-          ;; Notify the listener of logical retractions.
-          (doseq [[token token-insertions] token-insertion-map]
-            (l/retract-facts-logical! listener node token token-insertions))
-
-          (doseq [[alpha-roots fact-group] (get-alphas-fn insertions)
-                  root alpha-roots]
-            (alpha-retract root fact-group memory transport listener))))))
+            (doseq [[alpha-roots fact-group] (get-alphas-fn insertions)
+                    root alpha-roots]
+              (alpha-retract root fact-group memory transport listener)))))))
 
   (get-join-keys [node] [])
 

--- a/src/test/clojure/clara/tools/test_inspect.clj
+++ b/src/test/clojure/clara/tools/test_inspect.clj
@@ -53,8 +53,8 @@
       ;; Retrieve the tokens matching the cold query. This test validates
       ;; the tokens contain the expected matching conditions by retrieving
       ;; them directly from the query in question.
-      (is (= [cold-rule-15-explanation cold-rule-10-explanation]
-             (get-in rule-dump [:query-matches cold-query]))
+      (is (= (frequencies [cold-rule-15-explanation cold-rule-10-explanation])
+             (frequencies (get-in rule-dump [:query-matches cold-query])))
           "Query matches test")
 
       ;; Retrieve tokens matching the hot rule.
@@ -68,8 +68,8 @@
           "Insertions test")
 
       ;; Ensure the first condition in the rule matches the expected facts.
-      (is (= [(->Temperature 15 "MCI") (->Temperature 10 "MCI")]
-             (get-in rule-dump [:condition-matches  (first (:lhs cold-rule))]))
+      (is (= (frequencies [(->Temperature 15 "MCI") (->Temperature 10 "MCI")])
+             (frequencies (get-in rule-dump [:condition-matches  (first (:lhs cold-rule))])))
           "Condition matches test")
 
       ;; Test the :fact->explanations key in the inspected session data.


### PR DESCRIPTION
These changes are explained more in https://github.com/rbrush/clara-rules/issues/184.

High-level overview:
- Mutable Java collection types used in transient local memory when items retracted
- Memory collections remain persistent and immutable unless there is a need for items to be retracted from them
- Memory is converted to completely persistent, immutable clj structures when `clara.rules.memory/to-persistent!` is called
- No changes to memory that doesn't directly interact with `clara.rules.memory/remove-first-of-each` (our potential hot spot we are fighting here)
- Flush all updates during `clara.rules.engine/flush-updates` (See [1] for more)
-- Remove (now superfluous) `retract-facts!` call for empty insertions in ProductionNode

Implementation notes:

- Added `clara.rules.memory/add-all!` to avoid Collection.addAll(Collection) of Java.  It performs a copy of the incoming collection as an array.  This is unnecessarily slow in some cases, especially when I was looking at time spent in clj data structures to array, and it isn't valuable.
- `clara.rules.memory/remove-first-of-each!` is used for memory removals on the JVM side.  The non-destructive `remove-first-of-each` is still used by JS side, as well as in a few places in clara.rules.engine.
- There has been a slight change sometimes in the order facts are propagated, so I had to fix a few order-dependent tests in clara.tools.test-inspect.  It looks like they had no reason to assume the order they were assuming though.  I made them order independent now.

Note I had, but didn't address with this change @ [2].


[1] 
- There used to be a fragile and hard to understand situation here.  `flush-updates` did not flush updates that resulted from flushing the current updates.  This should be a recursive process.  Instead the ProductionNode happened to stage an "empty" activation when performing the `clara.rules.memory/remove-activations!`.
- Counterintuitively, `remove-activations!` was able to add new activations.  They didn't do anything other than cause the agenda group to possibly change, which resulted in additional (and necessary!) `flush-updates` calls.  I couldn't break the existing behavior, but I'm not confident that it doesn't have edge cases that this wouldn't flush all updates prior to switching to a lower priority agenda group.
- `clara.test-rules/test-flush-all-updates-before-changing-activation-group` is an example to test this odd case to make sure it is working both before and after these changes.

[2] 
- Applies to https://github.com/rbrush/clara-rules/blob/0.11.1/src/main/clojure/clara/rules/memory.cljc#L499
- There cannot be a previous when building and iterating from the incoming map right?  Keys have to be unique.  I don't think there is any reason to check for previous here.  Also, activations probably cannot be nil here anyways, but it doesn't necessarily hurt to check...  Adding and removing activations should just never associate nil to a key.  That isn't useful.
