### PR TITLE
Issue 182: Prevent nil accumulator results from propagating and avoid…

### DIFF
--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -654,9 +654,8 @@
 
 (defn- retract-accumulated
   "Helper function to retract an accumulated value."
-  [node accum-condition accumulator result-binding token result fact-bindings transport memory listener]
-  (let [converted-result ((:convert-return-fn accumulator) result)
-        new-facts (conj (:matches token) [converted-result (:id node)])
+  [node accum-condition accumulator result-binding token converted-result fact-bindings transport memory listener]
+  (let [new-facts (conj (:matches token) [converted-result (:id node)])
         new-bindings (merge (:bindings token)
                             fact-bindings
                             (when result-binding
@@ -668,9 +667,8 @@
 
 (defn- send-accumulated
   "Helper function to send the result of an accumulated value to the node's children."
-  [node accum-condition accumulator result-binding token result fact-bindings transport memory listener]
-  (let [converted-result ((:convert-return-fn accumulator) result)
-        new-bindings (merge (:bindings token)
+  [node accum-condition accumulator result-binding token converted-result fact-bindings transport memory listener]
+  (let [new-bindings (merge (:bindings token)
                             fact-bindings
                             (when result-binding
                               { result-binding
@@ -687,7 +685,7 @@
               (= previous-result converted-result))
 
       (send-tokens transport memory listener (:children node)
-                 [(->Token (conj (:matches token) [converted-result (:id node)]) new-bindings)]))))
+                   [(->Token (conj (:matches token) [converted-result (:id node)]) new-bindings)]))))
 
 (defn- has-keys?
   "Returns true if the given map has all of the given keys."
@@ -695,50 +693,67 @@
   (every? (partial contains? m) keys))
 
 ;; The AccumulateNode hosts Accumulators, a Rete extension described above, in the Rete network
-;; It behavios similarly to a JoinNode, but performs an accumulation function on the incoming
+;; It behaves similarly to a JoinNode, but performs an accumulation function on the incoming
 ;; working-memory elements before sending a new token to its descendents.
 (defrecord AccumulateNode [id accum-condition accumulator result-binding children binding-keys]
   ILeftActivate
   (left-activate [node join-bindings tokens memory transport listener]
-    (let [previous-results (mem/get-accum-reduced-all memory node join-bindings)]
+    (let [previous-results (mem/get-accum-reduced-all memory node join-bindings)
+          convert-return-fn (:convert-return-fn accumulator)]
       (mem/add-tokens! memory node join-bindings tokens)
 
       (doseq [token tokens]
 
         (cond
 
-         ;; If there are previously accumulated results to propagate, simply use them.
-         (seq previous-results)
-         (doseq [[fact-bindings previous] previous-results]
-           (send-accumulated node accum-condition accumulator result-binding token previous fact-bindings transport memory listener))
+          ;; If there are previously accumulated results to propagate, simply use them.
+          (seq previous-results)
+          (doseq [[fact-bindings previous] previous-results
+                  :let [converted (when previous
+                                    (convert-return-fn previous))]
+                  :when converted]
+            (send-accumulated node accum-condition accumulator result-binding token
+                              converted fact-bindings transport memory listener))
 
-         ;; There are no previously accumulated results, but we still may need to propagate things
-         ;; such as a sum of zero items.
-         ;; If all variables in the accumulated item are bound and an initial
-         ;; value is provided, we can propagate the initial value as the accumulated item.
+          ;; There are no previously accumulated results, but we still may need to propagate things
+          ;; such as a sum of zero items.
+          ;; If all variables in the accumulated item are bound and an initial
+          ;; value is provided, we can propagate the initial value as the accumulated item.
 
-         (and (has-keys? (:bindings token)
-                         binding-keys) ; All bindings are in place.
-              (:initial-value accumulator)) ; An initial value exists that we can propagate.
-         (let [fact-bindings (select-keys (:bindings token) binding-keys)
-               previous (:initial-value accumulator)]
+          (and (has-keys? (:bindings token)
+                          binding-keys) ; All bindings are in place.
+               (:initial-value accumulator)) ; An initial value exists that we can propagate.
+          (let [fact-bindings (select-keys (:bindings token) binding-keys)
+                initial-value (:initial-value accumulator)
+                ;; Note that we check that the :initial-value is truthy above, which is why we
+                ;; don't need (when initial-value (convert-return-fn initial-value)) here.
+                initial-converted (convert-return-fn initial-value)]
+            
+            (l/add-accum-reduced! listener node join-bindings initial-value fact-bindings)
 
-           ;; Send the created accumulated item to the children.
-           (send-accumulated node accum-condition accumulator result-binding token previous fact-bindings transport memory listener)
+            ;; Add it to the working memory.
+            (mem/add-accum-reduced! memory node join-bindings initial-value fact-bindings)
 
-           (l/add-accum-reduced! listener node join-bindings previous fact-bindings)
+            (when initial-converted
+              
+              ;; Send the created accumulated item to the children.
+              (send-accumulated node accum-condition accumulator result-binding token
+                                initial-converted fact-bindings transport memory listener))) 
 
-           ;; Add it to the working memory.
-           (mem/add-accum-reduced! memory node join-bindings previous fact-bindings))
-
-         ;; Propagate nothing if the above conditions don't apply.
-         :default nil))))
+          ;; Propagate nothing if the above conditions don't apply.
+          :default nil))))
 
   (left-retract [node join-bindings tokens memory transport listener]
-    (let [previous-results (mem/get-accum-reduced-all memory node join-bindings)]
+    (let [convert-return-fn (:convert-return-fn accumulator)
+          previous-results (mem/get-accum-reduced-all memory node join-bindings)]
       (doseq [token (mem/remove-tokens! memory node join-bindings tokens)
-              [fact-bindings previous] previous-results]
-        (retract-accumulated node accum-condition accumulator result-binding token previous fact-bindings transport memory listener))))
+              [fact-bindings previous] previous-results
+              :let [previous-converted (when previous
+                                         (convert-return-fn previous))]
+              ;; A falsey previous result should not have been propagated before.
+              :when previous-converted]
+        (retract-accumulated node accum-condition accumulator result-binding token
+                             previous-converted fact-bindings transport memory listener))))
 
   (get-join-keys [node] binding-keys)
 
@@ -754,36 +769,85 @@
                  (r/map :fact element-group))]))
 
   (right-activate-reduced [node join-bindings reduced-seq  memory transport listener]
+    
     ;; Combine previously reduced items together, join to matching tokens,
     ;; and emit child tokens.
-    (doseq [:let [matched-tokens (mem/get-tokens memory node join-bindings)]
+    (doseq [:let [convert-return-fn (:convert-return-fn accumulator)
+                  matched-tokens (mem/get-tokens memory node join-bindings)]
             [bindings reduced] reduced-seq
-            :let [previous (mem/get-accum-reduced memory node join-bindings bindings)]]
+            :let [previous (mem/get-accum-reduced memory node join-bindings bindings)
+                  combined (if (not= :clara.rules.memory/no-accum-reduced previous)
+                             ((:combine-fn accumulator) previous reduced)
+                             reduced)
+                  converted (when combined
+                              (convert-return-fn combined))
 
-      (if (not= :clara.rules.memory/no-accum-reduced previous)
+                  ;; The convert-return-fn should not be expected to handle the internal Clara implementation
+                  ;; detail of the :clara.rules.memory/no-accum-reduced keyword.  It is valid to simply consider
+                  ;; this keyword a nil converted result here since both it and nil are things that do not represent
+                  ;; valid data to propagate downstream and will cause all downstream Rete operations on this data
+                  ;; to be suppressed.
+                  
+                  previous-converted (when (and (not= previous :clara.rules.memory/no-accum-reduced)
+                                                previous)
+                                       (convert-return-fn previous))]]
 
-        ;; A previous value was reduced, so we need to retract it.
+      (l/add-accum-reduced! listener node join-bindings combined bindings)
+
+      (mem/add-accum-reduced! memory node join-bindings combined bindings)
+
+      (cond
+
+        (= previous :clara.rules.memory/no-accum-reduced)
+        
+        (let [initial-value (:initial-value accumulator)
+              ;; If the initial value (not the converted return value) is nil, then the accumulator will not propagate.
+              ;; This was existing behavior prior to issue 182.  As a result, convert-return-fn values that are not nil
+              ;; safe were supported.  We avoid calling the convert-return-fn if the initial value is nil in order to
+              ;; avoid breaking such code.
+              initial-converted (and
+                                 initial-value
+                                 (convert-return-fn initial-value))]
+          (do 
+            ;; A nil initial value should not have been propagated.
+            (when initial-converted
+              (doseq [token matched-tokens]
+                ;; Note that retract-accumulated will add the result binding.
+                (retract-accumulated node accum-condition accumulator result-binding token initial-converted
+                                     {} transport memory listener)))
+
+            ;; We only want to propagate the new value if it is truthy.
+            (when converted
+              (doseq [token matched-tokens]
+                (send-accumulated node accum-condition accumulator result-binding token converted bindings transport memory listener)))))
+
+        (and (not previous-converted)
+             (not converted))
+        nil ;; Do nothing when the result was nil before and after.
+
+        (and previous-converted
+             (not converted))
         (doseq [token matched-tokens]
           (retract-accumulated node accum-condition accumulator result-binding token
-                               previous bindings transport memory listener))
+                               previous-converted bindings transport memory listener))
 
-        ;; The accumulator has an initial value that is effectively the previous result when
-        ;; there was no previous item, so retract it.
-        (when-let [initial-value (:initial-value accumulator)]
-          (doseq [token matched-tokens]
-            (retract-accumulated node accum-condition accumulator result-binding token initial-value
-                                 {result-binding initial-value} transport memory listener))))
-
-      ;; Combine the newly reduced values with any previous items.
-      (let [combined (if (not= :clara.rules.memory/no-accum-reduced previous)
-                       ((:combine-fn accumulator) previous reduced)
-                       reduced)]
-
-        (l/add-accum-reduced! listener node join-bindings combined bindings)
-
-        (mem/add-accum-reduced! memory node join-bindings combined bindings)
+        (and converted
+             (not previous-converted))
         (doseq [token matched-tokens]
-          (send-accumulated node accum-condition accumulator result-binding token combined bindings transport memory listener)))))
+          (send-accumulated node accum-condition accumulator result-binding token converted bindings transport memory listener))
+        
+
+        ;; If there are previous results, then propagate downstream if the new result differs from the previous result.  If the new
+        ;; result is equal to the previous result don't do anything.  Note that the memory has already been updated with the new combined value,
+        ;; which may be needed for truth maintenance later.
+        (not= converted previous-converted)
+        
+        (do
+          (doseq [token matched-tokens]
+            (retract-accumulated node accum-condition accumulator result-binding token
+                                 previous-converted bindings transport memory listener))
+          (doseq [token matched-tokens]
+            (send-accumulated node accum-condition accumulator result-binding token converted bindings transport memory listener))))))
 
   IRightActivate
   (right-activate [node join-bindings elements memory transport listener]
@@ -800,7 +864,8 @@
 
   (right-retract [node join-bindings elements memory transport listener]
 
-    (doseq [:let [matched-tokens (mem/get-tokens memory node join-bindings)]
+    (doseq [:let [convert-return-fn (:convert-return-fn accumulator)
+                  matched-tokens (mem/get-tokens memory node join-bindings)]
             [bindings elements] (platform/tuned-group-by :bindings elements)
             :let [previous (mem/get-accum-reduced memory node join-bindings bindings)]
 
@@ -809,100 +874,122 @@
 
             ;; Compute the new version with the retracted information.
             :let [facts (mapv :fact elements)
-                  retracted (r/reduce (:retract-fn accumulator) previous facts)]]
+                  retracted (r/reduce (:retract-fn accumulator) previous facts)
+                  retracted-converted (when retracted
+                                        (convert-return-fn retracted))
+                  previous-converted (when previous
+                                       (convert-return-fn previous))]]
 
       ;; Add our newly retracted information to our node.
       (mem/add-accum-reduced! memory node join-bindings retracted bindings)
-      
-      ;; Get all of the previously matched tokens so we can retract and re-send them.
-      (doseq [token matched-tokens]
 
-        ;; Retract the previous token.
-        (retract-accumulated node accum-condition accumulator result-binding token previous bindings transport memory listener)
+      (cond
+        (and (not previous-converted)
+             (not retracted-converted))
+        nil
 
-        ;; Send a new accumulated token with our new, retracted information.
-        (when retracted
-          (send-accumulated node accum-condition accumulator result-binding token retracted bindings transport memory listener))))))
+        (not previous-converted)
+        (doseq [token matched-tokens]
+          (send-accumulated node accum-condition accumulator result-binding token retracted-converted bindings transport memory listener))
+
+        (not retracted-converted)
+        (doseq [token matched-tokens]
+          (retract-accumulated node accum-condition accumulator result-binding token previous-converted bindings transport memory listener))
+
+        (not= retracted-converted previous-converted)
+        (doseq [token matched-tokens]
+          (retract-accumulated node accum-condition accumulator result-binding token previous-converted bindings transport memory listener)
+          (send-accumulated node accum-condition accumulator result-binding token retracted-converted bindings transport memory listener))))))
 
 (defn- do-accumulate
-  "Runs the actual accumulation.  Returns the accumulated value if there are candidate facts
-   that match the join filter or if there is an :initial-value to propagate from the accumulator.
-   If neither of these conditions are true, ::no-accum-result is returned to indicate so.
-   Note:  A returned value of nil is not the same as ::no-accum-result.  A nil value may be the result
-          of running the accumulator over facts matching the token."
+  "Runs the actual accumulation.  Returns the accumulated value."
   [accumulator join-filter-fn token candidate-facts]
   (let [filtered-facts (filter #(join-filter-fn token % {}) candidate-facts)] ;; TODO: and env
-
-    (if (or (:initial-value accumulator) (seq filtered-facts))
+    (if (seq filtered-facts)
       (r/reduce (:reduce-fn accumulator)
                 (:initial-value accumulator)
                 filtered-facts)
-      ::no-accum-result)))
+      (:initial-value accumulator))))
 
 ;; A specialization of the AccumulateNode that supports additional tests
 ;; that have to occur on the beta side of the network. The key difference between this and the simple
 ;; accumulate node is the join-filter-fn, which accepts a token and a fact and filters out facts that
 ;; are not consistent with the given token.
 (defrecord AccumulateWithJoinFilterNode [id accum-condition accumulator join-filter-fn
-                                            result-binding children binding-keys]
+                                         result-binding children binding-keys]
   ILeftActivate
   (left-activate [node join-bindings tokens memory transport listener]
 
     ;; Facts that are candidates for matching the token are used in this accumulator node,
     ;; which must be filtered before running the accumulation.
-    (let [grouped-candidate-facts (mem/get-accum-reduced-all memory node join-bindings)]
+    (let [convert-return-fn (:convert-return-fn accumulator)
+          grouped-candidate-facts (mem/get-accum-reduced-all memory node join-bindings)]
       (mem/add-tokens! memory node join-bindings tokens)
 
       (doseq [token tokens]
 
         (cond
 
-         (seq grouped-candidate-facts)
-         (doseq [[fact-bindings candidate-facts] grouped-candidate-facts
+          (seq grouped-candidate-facts)
+          (doseq [[fact-bindings candidate-facts] grouped-candidate-facts
 
-                 ;; Filter to items that match the incoming token, then apply the accumulator.
-                 :let [accum-result (do-accumulate accumulator join-filter-fn token candidate-facts)]
+                  ;; Filter to items that match the incoming token, then apply the accumulator.
+                  :let [accum-result (do-accumulate accumulator join-filter-fn token candidate-facts)
+                        converted-result (when accum-result
+                                           (convert-return-fn accum-result))] 
 
-                 ;; There is nothing to propagate if nothing was accumulated.
-                 :when (not= ::no-accum-result accum-result)]
+                  :when converted-result]
 
-           (send-accumulated node accum-condition accumulator result-binding token accum-result fact-bindings transport memory listener))
+            (send-accumulated node accum-condition accumulator result-binding token
+                              converted-result fact-bindings transport memory listener))
 
-         ;; There are no previously accumulated results, but we still may need to propagate things
-         ;; such as a sum of zero items.
-         ;; If all variables in the accumulated item are bound and an initial
-         ;; value is provided, we can propagate the initial value as the accumulated item.
+          ;; There are no previously accumulated results, but we still may need to propagate things
+          ;; such as a sum of zero items.
+          ;; If all variables in the accumulated item are bound and an initial
+          ;; value is provided, we can propagate the initial value as the accumulated item.
 
-         (and (has-keys? (:bindings token)
-                         binding-keys) ; All bindings are in place.
-              (:initial-value accumulator)) ; An initial value exists that we can propagate.
-         (let [fact-bindings (select-keys (:bindings token) binding-keys)
-               initial-value (:initial-value accumulator)]
+          (and (has-keys? (:bindings token)
+                          binding-keys) ; All bindings are in place.
+               ;; We need to not propagate nil initial values, regardless of whether the convert-return-fn
+               ;; makes them non-nil, in order to not break existing code; this is discussed more in the
+               ;; right-activate-reduced implementation.
+               (:initial-value accumulator)) ; An initial value exists that we can propagate.
+          (let [fact-bindings (select-keys (:bindings token) binding-keys)
+                initial-value (:initial-value accumulator)
+                ;; Note that we check the the :initial-value is truthy above, which is why we
+                ;; don't need (when initial-value (convert-return-fn initial-value)) here.
+                converted-result (convert-return-fn initial-value)]
 
-           ;; Send the created accumulated item to the children.
-           (send-accumulated node accum-condition accumulator result-binding token initial-value fact-bindings transport memory listener)
+            ;; This accumulator keeps candidate facts rather than fully reduced values in the working memory,
+            ;; since the reduce operation must occur per token. Since there are no candidate facts
+            ;; in this flow, just put an empty vector into our memory.
+            (l/add-accum-reduced! listener node join-bindings [] fact-bindings)
+            (mem/add-accum-reduced! memory node join-bindings [] fact-bindings)
 
-           ;; This accumulator keeps candidate facts rather than fully reduced values in the working memory,
-           ;; since the reduce operation must occur per token. Since there are no candidate facts
-           ;; in this flow, just put an empty vector into our memory.
-           (l/add-accum-reduced! listener node join-bindings [] fact-bindings)
-           (mem/add-accum-reduced! memory node join-bindings [] fact-bindings))
+            (when converted-result
+              ;; Send the created accumulated item to the children.
+              (send-accumulated node accum-condition accumulator result-binding token
+                                converted-result fact-bindings transport memory listener))
 
-         ;; Propagate nothing if the above conditions don't apply.
-         :default nil))))
+            ;; Propagate nothing if the above conditions don't apply.
+            :default nil)))))
 
   (left-retract [node join-bindings tokens memory transport listener]
 
-    (let [grouped-candidate-facts (mem/get-accum-reduced-all memory node join-bindings)]
+    (let [convert-return-fn (:convert-return-fn accumulator)
+          grouped-candidate-facts (mem/get-accum-reduced-all memory node join-bindings)]
       (doseq [token (mem/remove-tokens! memory node join-bindings tokens)
               [fact-bindings candidate-facts] grouped-candidate-facts
 
-              :let [accum-result (do-accumulate accumulator join-filter-fn token candidate-facts)]
+              :let [accum-result (do-accumulate accumulator join-filter-fn token candidate-facts)
+                    retracted-converted (when accum-result
+                                          (convert-return-fn accum-result))]
 
-              ;; There is nothing to retract if nothing was accumulated.
-              :when (not= ::no-accum-result accum-result)]
+              ;; A falsey retracted previous result should not have been propagated before.
+              :when retracted-converted]
 
-        (retract-accumulated node accum-condition accumulator result-binding token accum-result fact-bindings transport memory listener))))
+        (retract-accumulated node accum-condition accumulator result-binding token
+                             retracted-converted fact-bindings transport memory listener))))
 
   (get-join-keys [node] binding-keys)
 
@@ -920,34 +1007,12 @@
 
     ;; Combine previously reduced items together, join to matching tokens,
     ;; and emit child tokens.
-    (doseq [:let [matched-tokens (mem/get-tokens memory node join-bindings)]
+    (doseq [:let [convert-return-fn (:convert-return-fn accumulator)
+                  matched-tokens (mem/get-tokens memory node join-bindings)]
             [bindings candidates] binding-candidates-seq
             :let [previous-candidates (mem/get-accum-reduced memory node join-bindings bindings)
                   previously-reduced? (not= :clara.rules.memory/no-accum-reduced previous-candidates)
                   previous-candidates (when previously-reduced? previous-candidates)]]
-
-      (if previously-reduced?
-
-       ;; Items were previously reduced that matched the bindings, so retract them to
-       ;; allow the newly accumulated result to propagate.
-       (doseq [token matched-tokens
-
-               :let [previous-accum-result (do-accumulate accumulator join-filter-fn token previous-candidates)]
-
-               ;; There is nothing to retract if nothing was accumulated.
-               :when (not= ::no-accum-result previous-accum-result)]
-
-         (retract-accumulated node accum-condition accumulator result-binding token
-                              previous-accum-result bindings transport memory listener))
-
-       ;; No items were previously reduced, but there may be an initial value that still needs to be
-       ;; retracted.
-       (when-let [initial-value (:initial-value accumulator)]
-
-         (doseq [token matched-tokens]
-
-           (retract-accumulated node accum-condition accumulator result-binding token initial-value
-                                {result-binding initial-value} transport memory listener))))
 
       ;; Combine the newly reduced values with any previous items.
       (let [combined-candidates (into previous-candidates candidates)]
@@ -957,12 +1022,55 @@
         (mem/add-accum-reduced! memory node join-bindings combined-candidates bindings)
         (doseq [token matched-tokens
 
-                :let [accum-result (do-accumulate accumulator join-filter-fn token combined-candidates)]
+                :let [accum-result (do-accumulate accumulator join-filter-fn token combined-candidates)
 
-                ;; There is nothing to propagate if nothing was accumulated.
-                :when (not= ::no-accum-result accum-result)]
+                      previous-accum-result (when previously-reduced?
+                                              (do-accumulate accumulator join-filter-fn token previous-candidates))
+                      
+                      previous-converted (when previous-accum-result
+                                           (convert-return-fn previous-accum-result))
+                      
+                      new-converted (when accum-result
+                                      (convert-return-fn accum-result))]]
 
-          (send-accumulated node accum-condition accumulator result-binding token accum-result bindings transport memory listener)))))
+          (cond
+            
+            (not previously-reduced?)
+            (let [initial-value (:initial-value accumulator)
+                  ;; If the initial value (not the converted return value) is nil, then the accumulator will not propagate.
+                  ;; This was existing behavior prior to issue 182.  As a result, convert-return-fn values that are not nil
+                  ;; safe were supported.  We avoid calling the convert-return-fn if the initial value is nil in order to
+                  ;; avoid breaking such code.
+                  initial-converted (and
+                                     initial-value
+                                     (convert-return-fn initial-value))]
+              (do
+                ;; A nil initial value should not have been propagated.
+                (when initial-converted
+                  ;; Note that retract-accumulated will add the result binding.
+                  (retract-accumulated node accum-condition accumulator result-binding token initial-converted
+                                       {} transport memory listener))
+
+                ;; We only want to propagate the initial value if it is truthy.
+                (when new-converted
+                  (send-accumulated node accum-condition accumulator result-binding token new-converted bindings transport memory listener))))
+
+            (and (not previous-converted)
+                 (not new-converted))
+            nil
+
+            (not new-converted)
+            (retract-accumulated node accum-condition accumulator result-binding token
+                                 previous-converted bindings transport memory listener)
+
+            (not previous-converted)
+            (send-accumulated node accum-condition accumulator result-binding token new-converted bindings transport memory listener)
+
+            (not= new-converted previous-converted)
+            
+            (do (retract-accumulated node accum-condition accumulator result-binding token
+                                     previous-converted bindings transport memory listener)
+                (send-accumulated node accum-condition accumulator result-binding token new-converted bindings transport memory listener)))))))
 
   IRightActivate
   (right-activate [node join-bindings elements memory transport listener]
@@ -979,7 +1087,8 @@
 
   (right-retract [node join-bindings elements memory transport listener]
 
-    (doseq [:let [matched-tokens (mem/get-tokens memory node join-bindings)]
+    (doseq [:let [convert-return-fn (:convert-return-fn accumulator)
+                  matched-tokens (mem/get-tokens memory node join-bindings)]
             [bindings elements] (platform/tuned-group-by :bindings elements)
             :let [previous-candidates (mem/get-accum-reduced memory node join-bindings bindings)]
 
@@ -997,15 +1106,31 @@
 
               ;; Compute the new version with the retracted information.
               :let [previous-result (do-accumulate accumulator join-filter-fn token previous-candidates)
-                    new-result (do-accumulate accumulator join-filter-fn token new-candidates)]]
+                    
+                    new-result (do-accumulate accumulator join-filter-fn token new-candidates)
+                    
+                    previous-converted (when previous-result
+                                         (convert-return-fn previous-result))
+                    
+                    new-converted (when new-result
+                                    (convert-return-fn new-result))]]
 
-        ;; Retract the previous token if something was previously accumulated.
-        (when (not= ::no-accum-result previous-result)
-          (retract-accumulated node accum-condition accumulator result-binding token previous-result bindings transport memory listener))
+        (cond
 
-        ;; Send a new accumulated token with our new, retracted information when there is a new result.
-        (when (and new-result (not= ::no-accum-result new-result))
-          (send-accumulated node accum-condition accumulator result-binding token new-result bindings transport memory listener))))))
+          (and (not previous-converted)
+               (not new-converted))
+          nil
+
+          (not new-converted)
+          (retract-accumulated node accum-condition accumulator result-binding token previous-converted bindings transport memory listener)
+
+          (not previous-converted)
+          (send-accumulated node accum-condition accumulator result-binding token new-converted bindings transport memory listener)
+
+          (not= previous-converted new-converted)
+          (do
+            (retract-accumulated node accum-condition accumulator result-binding token previous-converted bindings transport memory listener)
+            (send-accumulated node accum-condition accumulator result-binding token new-converted bindings transport memory listener)))))))
 
 (defn variables-as-keywords
   "Returns symbols in the given s-expression that start with '?' as keywords"

--- a/src/test/clojure/clara/tools/test_tracing.clj
+++ b/src/test/clojure/clara/tools/test_tracing.clj
@@ -66,9 +66,9 @@
                     (insert (->Temperature 10 "MCI"))
                     (insert (->Temperature 80 "MCI")))]
 
-    (is (= [:add-facts :accum-reduced :left-activate :add-facts
-            :left-retract :accum-reduced :left-activate :add-facts
-            :left-retract :accum-reduced :left-activate]
+    (is (= [:add-facts :accum-reduced :left-activate
+            :add-facts :accum-reduced :left-retract
+            :left-activate :add-facts :accum-reduced]
 
            (map :type (t/get-trace session))))))
 


### PR DESCRIPTION
… propagation from accumulators when the Rete operation does not change the final result

Some notes here:

- If the retracted or reduced value from an accumulator is nil, this assumes that the converted return
value is also nil.  Currently, because a nil initial value does not propagate and we don't propagate nils that come from retractions (as opposed to propagation) an accumulator that has a nil initial value and takes on a non-nil value for any actual data can have a convert-return-fn that is not nil safe.  Making such a non-passive change to support a pattern that is probably not that common anyway (taking a nil value and converting it to something truthy) didn't seem worth the complication/risk.  Furthermore, such convert-return functions would be unsafe anyway now since any retraction, even one that didn't change the final value, would cause retraction of the relevant tokens. [1, 2] This could be revisited in [3, 4, 5].  Does this approach seem correct to you?
- Since a nil value will be ineligible for propagation, I don't think we need to special-case ::no-accum-result in do-accumulate anymore. [6] We can just return nil there and the output will be suppressed.
- I don't think [7] or [8] needs
````
{result-binding initial-value}
````
since the result-binding will be added (and overridden) anyway by [9].  Furthermore, this binding is invalid because it is the initial-value, not the initial value after application of the convert-return-fn.  I removed this bindings map and replaced it with an empty map.

Let me know if you can think of additional test cases that you'd like to have and I'd be happy to add them.  The various pieces of accumulator logic can interact in a lot of different ways, which makes figuring out which sorts of test cases will provide the best benefit versus cost a difficult calculation.  This is particularly true for tests that are targeted at a particular implementation detail, even if they don't depend on that implementation detail to pass (they might just lose value if that implementation detail changed).  Overall, I think generative tests for accumulators, even if the generated part was just data and/or insert/retract patterns, rather than the actual rules or accumulators themselves, are a idea worth exploring to help cope with the large set of possible interactions.  However, that also seems out of scope here, and such tests would probably fail right now anyway due to [4, 5].

@mrrodriguez will probably want to take a look at this as well before merging.  I think there is enough complication and edge cases here to merit more than one pair of eyes over it.

1. https://github.com/rbrush/clara-rules/blob/0.11.1/src/main/clojure/clara/rules/engine.cljc#L821
2. https://github.com/rbrush/clara-rules/blob/0.11.1/src/main/clojure/clara/rules/engine.cljc#L1004
3. https://github.com/rbrush/clara-rules/issues/190
4. https://github.com/rbrush/clara-rules/issues/189
5. https://github.com/rbrush/clara-rules/issues/188
6. https://github.com/rbrush/clara-rules/blob/0.11.1/src/main/clojure/clara/rules/engine.cljc#L837
7. https://github.com/rbrush/clara-rules/blob/0.11.1/src/main/clojure/clara/rules/engine.cljc#L772
8. https://github.com/rbrush/clara-rules/blob/0.11.1/src/main/clojure/clara/rules/engine.cljc#L946
9. https://github.com/rbrush/clara-rules/blob/0.11.1/src/main/clojure/clara/rules/engine.cljc#L659
