### PR TITLE
Fix to-dnf to support :exists inside :and and :or conditions

### DIFF
--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -461,6 +461,8 @@
 
         :test expression
 
+        ;; Note that :exists does not support further nested boolean conditions.
+        ;; It is just syntax sugar over an accumulator.
         :exists expression
 
         ;; Double negation, so just return the expression under the second negation.
@@ -476,7 +478,7 @@
     ;; For all others, recursively process the children.
     (let [children (map to-dnf (rest expression))
           ;; Get all conjunctions, which will not conain any disjunctions since they were processed above.
-          conjunctions (filter #(#{:and :condition :not} (expr-type %)) children)]
+          conjunctions (filter #(#{:and :condition :not :exists} (expr-type %)) children)]
 
       ;; If there is only one child, the and or or operator can simply be eliminated.
       (if (= 1 (count children))

--- a/src/test/clojure/clara/test_rules.clj
+++ b/src/test/clojure/clara/test_rules.clj
@@ -3329,6 +3329,48 @@
                (query wind-and-temp)
                (set))))))
 
+(deftest test-exists-inside-boolean-conjunction-and-disjunction
+  (let [or-rule (dsl/parse-rule [[:or
+                                  [:exists [ColdAndWindy]]
+                                  [:exists [Temperature (< temperature 20)]]]]
+                                (insert! (->Cold nil)))
+
+        and-rule (dsl/parse-rule [[:and
+                                   [:exists [ColdAndWindy]]
+                                   [:exists [Temperature (< temperature 20)]]]]
+                                 (insert! (->Cold nil)))
+
+        cold-query (dsl/parse-query [] [[Cold (= ?t temperature)]])
+
+        or-session (mk-session [or-rule cold-query] :cache false)
+
+        and-session (mk-session [and-rule cold-query] :cache false)]
+
+    (is (empty? (-> or-session
+                    fire-rules
+                    (query cold-query)))
+        "Verify that :exists under an :or does not fire if nothing meeting the :exists is present")
+
+    (is (= (-> or-session
+               (insert (->ColdAndWindy 10 10))
+               fire-rules
+               (query cold-query))
+           [{:?t nil}])
+        "Validate that :exists can match under a boolean :or condition.")
+
+    (is (empty? (-> and-session
+                    (insert (->ColdAndWindy 10 10))
+                    fire-rules
+                    (query cold-query)))
+        "Validate that :exists under an :and condition without both conditions does not cause the rule to fire.")
+
+    (is (= (-> and-session
+               (insert (->ColdAndWindy 10 10) (->Temperature 10 "MCI"))
+               fire-rules
+               (query cold-query))
+           [{:?t nil}])
+        "Validate that :exists can match under a boolean :and condition.")))
+
 ;; Test for https://github.com/rbrush/clara-rules/issues/142
 (deftest test-beta-binding
   "Tests bind operation that must happen on the beta side of the network"
@@ -4173,4 +4215,5 @@
                fire-rules
                (query cold-and-windy-query))
            [{:?t false}])
-        (str "The minimum temperature should retract back to boolean false for node type " node-type))))     
+        (str "The minimum temperature should retract back to boolean false for node type " node-type))))
+


### PR DESCRIPTION
The basic problem here is that to-dnf currently considers everything to be either a "conjunction" or "disjunction" when processing the children of :and and :or conditions. [1]  In this code, it looks to me like anything that is not a :or condition is considered to fall in the conjunctions bucket.  This is done by filtering on the condition type for each child.  :exists is currently not considered to be either, so it just gets filtered out of the dnf form completely.

Current state:
````
clara.test-rules> (com/to-dnf [:or [:exists {:constraints []}] [:exists {:constraints []}]])
(:or)
````

State after this change:

````
clara.test-rules> (com/to-dnf [:or [:exists {:constraints []}] [:exists {:constraints []}]])
(:or [:exists {:constraints []}] [:exists {:constraints []}])
````

1. https://github.com/rbrush/clara-rules/blob/0.11.1/src/main/clojure/clara/rules/compiler.clj#L477