### PR TITLE
AccumulateNode no longer requires :combine-fn or :retract-fn

### DIFF
--- a/src/main/clojure/clara/rules.cljc
+++ b/src/main/clojure/clara/rules.cljc
@@ -111,18 +111,16 @@
 
    * An initial-value to be used with the reduced operations.
    * A reduce-fn that can be used with the Clojure Reducers library to reduce items.
-   * A combine-fn that can be used with the Clojure Reducers library to combine reduced items.
-   * A retract-fn that can remove a retracted fact from a previously reduced computation
+   * An optional combine-fn that can be used with the Clojure Reducers library to combine reduced items.
+   * An optional retract-fn that can remove a retracted fact from a previously reduced computation
    * An optional convert-return-fn that converts the reduced data into something useful to the caller.
      Simply uses identity by default.
     "
   [& {:keys [initial-value reduce-fn combine-fn retract-fn convert-return-fn] :as args}]
   (eng/map->Accumulator
-   (merge
-    {:combine-fn reduce-fn ; Default combine function is simply the reduce.
-     :convert-return-fn identity ; Default conversion does nothing, so use identity.
-     }
-    args)))
+   (merge {;; Default conversion does nothing, so use identity.
+           :convert-return-fn identity}
+          args)))
 
 #?(:cljs
   (defrecord Rulebase [alpha-roots beta-roots productions queries production-nodes query-nodes id-to-node]))

--- a/src/main/clojure/clara/rules/durability.clj
+++ b/src/main/clojure/clara/rules/durability.clj
@@ -118,7 +118,7 @@
 
       (eng/right-activate-reduced (id-to-node id)
                                   join-bindings
-                                  [[fact-bindings result]]
+                                  [[fact-bindings (first result)]]
                                   transient-memory
                                   transport
                                   (l/to-transient l/default-listener)))

--- a/src/main/clojure/clara/rules/listener.cljc
+++ b/src/main/clojure/clara/rules/listener.cljc
@@ -16,6 +16,7 @@
   (retract-facts! [listener facts])
   (retract-facts-logical! [listener node token facts])
   (add-accum-reduced! [listener node join-bindings result fact-bindings])
+  (remove-accum-reduced! [listener node join-bindings fact-bindings])
   (add-activations! [listener node activations])
   (remove-activations! [listener node activations])
   (fire-rules! [listener node])
@@ -41,6 +42,8 @@
   (retract-facts-logical! [listener node token facts]
     listener)
   (add-accum-reduced! [listener node join-bindings result fact-bindings]
+    listener)
+  (remove-accum-reduced! [listener node join-bindings fact-bindings]
     listener)
   (add-activations! [listener node activations]
     listener)
@@ -95,6 +98,10 @@
   (add-accum-reduced! [listener node join-bindings result fact-bindings]
     (doseq [child children]
       (add-accum-reduced! child node join-bindings result fact-bindings)))
+
+  (remove-accum-reduced! [listener node join-bindings fact-bindings]
+    (doseq [child children]
+      (remove-accum-reduced! child node join-bindings fact-bindings)))
 
   (add-activations! [listener node activations]
     (doseq [child children]

--- a/src/main/clojure/clara/rules/memory.cljc
+++ b/src/main/clojure/clara/rules/memory.cljc
@@ -71,6 +71,9 @@
   ;; Adds the result of a reduced accumulator execution to the given memory and node.
   (add-accum-reduced! [memory node join-bindings accum-result fact-bindings])
 
+  ;; Removes the result of a reduced accumulator execution to the given memory and node.
+  (remove-accum-reduced! [memory node join-bindings fact-bindings])
+
   ;; Add a record that a given fact twas inserted at a given node with
   ;; the given support. Used for truth maintenance.
   ;; This should be called at most once per rule activation.
@@ -546,6 +549,21 @@
                   (assoc-in (get accum-memory (:id node) {})
                             [join-bindings fact-bindings]
                             accum-result))))
+
+  (remove-accum-reduced! [memory node join-bindings fact-bindings]
+    (let [node-id (:id node)
+          node-id-mem (get accum-memory node-id {})
+          join-mem (dissoc (get node-id-mem join-bindings) fact-bindings)
+          node-id-mem (if (empty? join-mem)
+                        (dissoc node-id-mem join-bindings)
+                        (assoc node-id-mem join-bindings join-mem))]
+      (set! accum-memory
+            (if (empty? node-id-mem)
+              (dissoc! accum-memory
+                       node-id)
+              (assoc! accum-memory
+                      node-id
+                      node-id-mem)))))
 
   ;; The value under each token in the map should be a sequence
   ;; of sequences of facts, with each inner sequence coming from a single

--- a/src/main/clojure/clara/tools/tracing.clj
+++ b/src/main/clojure/clara/tools/tracing.clj
@@ -45,6 +45,12 @@
                             :result result
                             :fact-bindings fact-bindings}))
 
+  (remove-accum-reduced! [listener node join-bindings fact-bindings]
+    (append-trace listener {:type :remove-accum-reduced
+                            :node-id (:id node)
+                            :join-bindings join-bindings
+                            :fact-bindings fact-bindings}))
+
   (add-activations! [listener node activations]
     (append-trace listener {:type :add-activations :node-id (:id node) :tokens (map :token activations)}))
 

--- a/src/test/clojure/clara/test_durability.clj
+++ b/src/test/clojure/clara/test_durability.clj
@@ -100,6 +100,7 @@
 
     ;; Accumulator returns the lowest value.
     (is (= #{{:?t (->Temperature 10 "MCI")}}
+           (set (query session coldest-query))
            (set (query restored-session coldest-query))))))
 
 (deftest test-restore-truth-maintenance

--- a/src/test/clojure/clara/tools/test_tracing.clj
+++ b/src/test/clojure/clara/tools/test_tracing.clj
@@ -70,7 +70,20 @@
             :add-facts :accum-reduced :left-retract
             :left-activate :add-facts :accum-reduced]
 
-           (map :type (t/get-trace session))))))
+           (map :type (t/get-trace session)))))
+
+  (testing "remove-accum-reduced"
+    (let [all-temps (dsl/parse-query [] [[?t <- (acc/all) from [Temperature]]])
+          
+          session (-> (mk-session [all-temps])
+                      (t/with-tracing)
+                      fire-rules
+                      (insert (->Temperature 15 "MCI"))
+                      fire-rules)]
+
+      (is (= [:add-facts :remove-accum-reduced :accum-reduced :left-retract :left-activate]
+
+             (map :type (t/get-trace session)))))))
 
 (deftest test-insert-trace
  (let [cold-rule (dsl/parse-rule [[Temperature (= ?temperature temperature) (< temperature 20)]]


### PR DESCRIPTION
- Addresses the issues 188, 189, and 200 for AccumulateNode
  - When given, :retract-fn is used though
- Default :retract-fn is built into the node
  - More performant than an external "retraction wrapper impl"
- :initial-value propagation semantics have been corrected (issue 188 and 189)
- :initial-value only added to memory once per all tokens in AccumulateNode left-activate
- :combine-fn is now optional and not provided by default for clara.rules.accumulators/reduce-to-accum
- Removed :combine-fn from built-in accumulators where it is not useful
- Test for retracting un-inserted fact in accumulate node (issue 200)
- Added tracing support to mem/remove-accum-reduced!