### PR TITLE
Making rule engine execution order more deterministic

### DIFF
--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -104,7 +104,7 @@
     (if (pos? (count join-keys))
 
       ;; Group by the join keys for the activation.
-      (doseq [[join-bindings item-group] (platform/tuned-group-by #(select-keys (:bindings %) join-keys) items)]
+      (doseq [[join-bindings item-group] (platform/group-by-seq #(select-keys (:bindings %) join-keys) items)]
         (propagate-fn node
                       join-bindings
                       item-group
@@ -805,7 +805,7 @@
   IAccumRightActivate
   (pre-reduce [node elements]
     ;; Return a seq tuples with the form [binding-group facts-from-group-elements].
-    (for [[bindings element-group] (platform/tuned-group-by :bindings elements)]
+    (for [[bindings element-group] (platform/group-by-seq :bindings elements)]
       [bindings (mapv :fact element-group)]))
 
   (right-activate-reduced [node join-bindings fact-seq memory transport listener]
@@ -948,7 +948,7 @@
     (doseq [:let [convert-return-fn (:convert-return-fn accumulator)
                   matched-tokens (mem/get-tokens memory node join-bindings)
                   has-matches? (seq matched-tokens)]
-            [bindings elements] (platform/tuned-group-by :bindings elements)
+            [bindings elements] (platform/group-by-seq :bindings elements)
 
             :let [previous (mem/get-accum-reduced memory node join-bindings bindings)
                   has-previous? (not= :clara.rules.memory/no-accum-reduced previous)
@@ -1130,7 +1130,7 @@
     ;; Return a map of bindings to the candidate facts that match them. This accumulator
     ;; depends on the values from parent facts, so we defer actually running the accumulator
     ;; until we have a token.
-    (for [[bindings element-group] (platform/tuned-group-by :bindings elements)]
+    (for [[bindings element-group] (platform/group-by-seq :bindings elements)]
       [bindings (map :fact element-group)]))
 
   (right-activate-reduced [node join-bindings binding-candidates-seq memory transport listener]
@@ -1220,7 +1220,7 @@
 
     (doseq [:let [convert-return-fn (:convert-return-fn accumulator)
                   matched-tokens (mem/get-tokens memory node join-bindings)]
-            [bindings elements] (platform/tuned-group-by :bindings elements)
+            [bindings elements] (platform/group-by-seq :bindings elements)
             :let [previous-candidates (mem/get-accum-reduced memory node join-bindings bindings)]
 
             ;; No need to retract anything if there was no previous item.

--- a/src/main/clojure/clara/rules/platform.cljc
+++ b/src/main/clojure/clara/rules/platform.cljc
@@ -8,6 +8,37 @@
   (throw #?(:clj (IllegalArgumentException. description) :cljs (js/Error. description))))
 
 #?(:clj
+   (defn group-by-seq
+     "Groups the items of the given coll by f to each item.  Returns a seq of tuples of the form 
+      [f-val xs] where xs are items from the coll and f-val is the result of applying f to any of 
+      those xs.  Each x in xs has the same value (f x).  xs will be in the same order as they were
+      found in coll.
+      The behavior is similar to calling `(seq (group-by f coll))` However, the returned seq will
+      always have consistent ordering from process to process.  The ordering is insertion order
+      as new (f x) values are found traversing the given coll collection in its seq order.  The
+      returned order is made consistent to ensure that relevant places within the rules engine that
+      use this grouping logic have deterministic behavior across different processes."
+     [f coll]
+     (let [^java.util.Map m (reduce (fn [^java.util.Map m x]
+                                      (let [k (f x)
+                                            xs (or (.get m k)
+                                                   (transient []))]
+                                        (.put m k (conj! xs x)))
+                                      m)
+                                    (java.util.LinkedHashMap.)
+                                    coll)
+           it (.iterator (.entrySet m))]
+       ;; Explicitly iterate over a Java iterator in order to avoid running into issues as
+       ;; discussed in http://dev.clojure.org/jira/browse/CLJ-1738
+       (loop [coll (transient [])]
+         (if (.hasNext it)
+           (let [^java.util.Map$Entry e (.next it)]
+             (recur (conj! coll [(.getKey e) (persistent! (.getValue e))])))
+           (persistent! coll)))))
+   :cljs
+   (def group-by-seq (comp seq clojure.core/group-by)))
+
+#?(:clj
     (defn tuned-group-by
       "Equivalent of the built-in group-by, but tuned for when there are many values per key."
       [f coll]


### PR DESCRIPTION
Clara currently uses `clara.rules.platform/tuned-group-by` in a number of places.  The grouping that this function does is unordered and often can vary from one JVM to the next.  In particular I've noticed this happening in the `clara.rules.engine/flush-updates` which was causing non-deterministic insertion order to happen across rules.  This makes it harder for us to track bad performance cases since they keep fluctuating as we run in different processes.

A side-effect of `flush-updates` not behaving deterministically was that insertion order across rules of the same salience group level were not deterministic and didn't necessarily respect rule load order as was implemented in https://github.com/rbrush/clara-rules/issues/192.  From my preliminary testing of this, I see a slight improvement in our execution times with this change in place.  This is likely due to the rule order now also being the insertion order used.  I've demonstrated this with a test that fails before this change and now passes.

My proposal is to (on the Java CLJ side) introduce a new `clara.rules.platform/group-by-seq` function that replaces the usages of `platform/tuned-group-by`.  Currently, I've left `platform/tuned-group-by` in case it ends up having some usages later.  It is also used in one CLJS place still, which I'm not wanting to change with this.  `platform/group-by-seq` returns a seq of tuples, which is the same as seq'ing over the map returned by `platform/tuned-group-by` before.  In all cases where we used `platform/tuned-group-by` we didn't use the map, but rather a seq over it.

I use a java.util.LinkedHashMap to maintain insertion order while building the groupings.  Then I convert this into an immutable seq structure.  If I tried to retain the usage of a map here, I'd have to return the java.util.LinkedHashMap or come up with some (expensive) way to port it into a Clojure sorted map.  This was not worthwhile to me, since we do not need a map anyways.  A java.util.LinkedHashMap would be harder to work with across the rest of the codebase since there are issues with the default Clojure seq implementations across mutable object iterators http://dev.clojure.org/jira/browse/CLJ-1738 that I see coming up when running this on JDK6 (oddly not on JDK8, which makes no sense and I want to investigate more for my own benefit).

Along with this, since I was messing with the `clara.rules.compiler/create-get-alphas-fn` already, I sorted the result of the ancestors-fn so that it would behave deterministically.  This would be more of an edge case, but since we cache this result and infrequently should hit this path, I figured it'd still be worthwhile.

