### PR TITLE
Add tests for AccumulateNode that insert the same facts and u…

### DIFF
--- a/src/test/clojure/clara/generative/generators.clj
+++ b/src/test/clojure/clara/generative/generators.clj
@@ -21,7 +21,8 @@
                                                     :retract (apply retract session (:facts op))
                                                     :fire (fire-rules session))]
                                   new-session))
-                              session ops)]))
+                              session ops)]
+    final-session))
 
 (defn ^:private retract-before-insertion?
   "Given a sequence of operations, determine if the number of retractions of any fact exceeds the number
@@ -83,7 +84,7 @@
    are added will be present.  The default number of such pairs allowed to be added per insertion
    is 1."
   [ops :- [SessionOperation]
-   {:keys [dup-level] :or {:dup-level 1}}]
+   {:keys [dup-level] :or {dup-level 0}}]
   (let [dup-ops-seqs (ops->add-insert-retract ops dup-level)
         permutations (mapcat combo/permutations dup-ops-seqs)]
     

--- a/src/test/clojure/clara/generative/test_accum.clj
+++ b/src/test/clojure/clara/generative/test_accum.clj
@@ -1,0 +1,155 @@
+(ns clara.generative.test-accum
+  (:require [clara.rules :refer :all]
+            [clojure.test :refer :all]
+            [clara.rules.testfacts :refer :all]
+            [clara.rules.accumulators :as acc]
+            [clara.rules.dsl :as dsl]
+            [schema.test]
+            [clara.generative.generators :as gen])
+  (import [clara.rules.testfacts Temperature WindSpeed Cold TemperatureHistory
+           ColdAndWindy]))
+
+(use-fixtures :once schema.test/validate-schemas)
+
+(deftest test-simple-all-condition-binding-groups
+  (let [r (dsl/parse-rule [[?ts <- (acc/all) :from [Temperature (= ?loc location)]]]
+                          ;; The all accumulator can return facts in different orders, so we sort
+                          ;; the temperatures to make asserting on the output easier.
+                          (insert! (->TemperatureHistory [?loc (sort (map :temperature ?ts))])))
+
+        q (dsl/parse-query [] [[?history <- TemperatureHistory]])
+
+        empty-session (mk-session [r q] :cache false)]
+
+    (let [operations [{:type :insert
+                       :facts [(->Temperature 11 "MCI")]}
+                      {:type :insert
+                       :facts [(->Temperature 19 "MCI")]}
+                      {:type :insert
+                       :facts [(->Temperature 1 "ORD")]}
+                      {:type :insert
+                       :facts [(->Temperature 22 "LAX")]}
+                      {:type :retract
+                       :facts [(->Temperature 22 "LAX")]}
+                      ;; Note that a :fire operation is added to the end later.  If this is at the end,
+                      ;; then it should be functionally the same as if we only had one at the end.
+                      ;; On the other hand, a fire operation in the middle of the operations could potentially
+                      ;; reveal bugs.
+                      {:type :fire}]
+
+          operation-permutations (gen/ops->permutations operations {})
+
+          expected-output? (fn [session permutation]
+                             (let [actual-temp-hist (-> session
+                                                        (query q)
+                                                        frequencies)
+                                   expected-temp-hist (frequencies [{:?history (->TemperatureHistory ["MCI" [11 19]])}
+                                                                    {:?history (->TemperatureHistory ["ORD" [1]])}])]
+                               (= actual-temp-hist expected-temp-hist)))]
+      
+      (doseq [permutation (map #(concat % [{:type :fire}]) operation-permutations)
+              :let [session (gen/session-run-ops empty-session permutation)]]
+        (is (expected-output? session permutation)
+            (str "Failure for operation permutation: "
+                 \newline
+                 ;; Put into a vector so that the str implementation shows the elements of the collection,
+                 ;; not just LazySeq.
+                 (into [] permutation)
+                 \newline
+                 "Output was: "
+                 \newline
+                 (into [] (query session q))))))
+
+    (let [operations (mapcat (fn [fact]
+                               [{:type :insert
+                                 :facts [fact]}
+                                {:type :retract
+                                 :facts [fact]}])
+                             [(->Temperature 10 "MCI")
+                              (->Temperature 20 "MCI")
+                              (->Temperature 15 "LGA")
+                              (->Temperature 25 "LGA")])
+
+          operation-permutations (gen/ops->permutations operations {})]
+      
+      (doseq [permutation (map #(concat % [{:type :fire}]) operation-permutations)
+              :let [session (gen/session-run-ops empty-session permutation)
+                    output (query session q)]]
+        (is (empty? output)
+            (str "Non-empty result for operation permutation: "
+                 \newline
+                 (into [] permutation)
+                 "Output was: "
+                 (into [] output)))))))
+
+(deftest test-min-accum-with-binding-groups
+  (let [coldest-rule (dsl/parse-rule [[?coldest-temp <- (acc/min :temperature :returns-fact true)
+                                       :from [ColdAndWindy (= ?w windspeed)]]]
+                                     (insert! (->Cold (:temperature ?coldest-temp))))
+        cold-query (dsl/parse-query [] [[?c <- Cold]])
+
+        empty-session (mk-session [coldest-rule cold-query] :cache false)
+
+        operations [{:type :insert
+                     :facts [(->ColdAndWindy 10 20)]}
+                    {:type :insert
+                     :facts [(->ColdAndWindy 5 20)]}
+                    {:type :retract
+                     :facts [(->ColdAndWindy 5 20)]}
+                    {:type :insert
+                     :facts [(->ColdAndWindy 20 20)]}
+                    {:type :insert
+                     :facts [(->ColdAndWindy 0 30)]}
+                    {:type :fire}]
+
+        operation-permutations (gen/ops->permutations operations {})]
+
+    (doseq [permutation (map #(concat % [{:type :fire}]) operation-permutations)
+            :let [session (gen/session-run-ops empty-session permutation)
+                  output (query session cold-query)]]
+      (is (= (frequencies output)
+             {{:?c (->Cold 0)} 1
+              {:?c (->Cold 10)} 1})
+          (str "The minimum cold temperatures per windspeed are not correct for permutation: "
+               \newline
+               (into [] permutation)
+               \newline
+               "The output was: "
+               (into [] output))))))
+
+(deftest test-min-accum-without-binding-groups
+  (let [coldest-rule (dsl/parse-rule [[?coldest <- (acc/min :temperature) :from [Cold]]]
+                                     (insert! (->Temperature ?coldest "MCI")))
+        temp-query (dsl/parse-query [] [[Temperature (= ?t temperature)]])
+
+        empty-session (mk-session [coldest-rule temp-query] :cache false)]
+
+    (doseq [temp-1 (range 5)
+            temp-2 (range 5)
+            temp-3 (range 5)
+
+            :let [operations [{:type :insert
+                               :facts [(->Cold temp-1)]}
+                              {:type :insert
+                               :facts [(->Cold temp-2)]}
+                              {:type :insert
+                               :facts [(->Cold temp-3)]}
+                              {:type :retract
+                               :facts [(->Cold temp-3)]}
+                              {:type :fire}]]
+
+            permutation (map #(concat % [{:type :fire}])
+                             (gen/ops->permutations operations {}))
+
+            :let [session (gen/session-run-ops empty-session permutation)
+                  output (query session temp-query)]]
+      
+      (is (= output
+             [{:?t (min temp-1 temp-2)}])
+          (str "Did not find the correct minimum temperature for permutation: "
+               \newline
+               (into [] permutation)
+               \newline
+               "Output was: "
+               \newline
+               (into [] output))))))


### PR DESCRIPTION
…se the same rules, but vary the insert, retract, and fire patterns

I changed the default insertion duplication level from 1 to 0 here.  This is functionality that would, for example, take the pattern

- Insert A

and change it to

- Insert A
- Insert A
- Retract A

and the various order permutations of the latter, as well as keeping the original single-insertion scenario.  When I tried using the generator with the previous default I found that it made tests take far too long to run in some scenarios I wanted, presumably due to the combinatorial explosion of permutations.

Overall, none of the tests in this PR are going to get into complex scenarios in the compiler, rules network, etc.  My target here is more of a sanity check to improve confidence that the insert and retract algorithms on the AccumulateNode work correctly; this is very much a test of the AccumulateNode in isolation.   The tests are still written in terms of rules and sessions rather than direct calls to the node of course, with the attending advantages in reducing test brittleness.  However, given that we've had bugs that were purely internal to the accumulator nodes, I think such testing could be helpful.