### PR TITLE
Issue 102: Prevent AccumulateWithJoinFilterNode from creating binding groups when t…

### DIFF
--- a/src/main/clojure/clara/rules/memory.cljc
+++ b/src/main/clojure/clara/rules/memory.cljc
@@ -204,15 +204,6 @@
     ;; There is nothing to remove.
     (empty? remove-seq) [[] coll]
 
-    ;; Optimization for special case of one item to remove,
-    ;; which occurs frequently.
-    (= 1 (count remove-seq))
-
-    (let [item-to-remove (first remove-seq)
-          [before-it [it & after-it]] (split-with #(not= item-to-remove %) coll)
-          removed (if it [it] [])]
-      [removed (into before-it after-it)])
-
     ;; Otherwise, perform a linear search for items to remove.
     :else (loop [f (first coll)
                  r (rest coll)


### PR DESCRIPTION
…here are no corresponding elements

I removed the special 1-element case of mem/remove-first-of-each since it changes the ordering of members of the collection of items that were not removed.  I believe the into call [1] is causing this.  If we look at split-with [2] it uses take-while, which creates a lazy sequence.  Into will append to the start of this sequence, so elements after the element removed will move to an earlier position.  I don't see a reason why this special case should be more performant than the current implementation for an arbitrary number of elements to remove; if anyone sees such a reason please explain it.  From looking through the history it looks like the general case was less efficient at one time.  Being able to guarantee that the ordering is unchanged allows us to make some performance optimizations.

The optimizations I made were

- In right-activate, accumulate the new elements on top of the result of the previous accumulation rather than re-accumulating from scratch.
- In right-retract, don't do anything for a token other than update the memory if the number of elements filtered for that token is the same before and after the retraction i.e. if none of the retracted elements matched that token in the first place.  If remove-first-of-each changes the ordering of elements then the ordering of elements in the memory will change, thus changing the accumulation order.  We cannot have a state where the elements are ordered like [element1 element2] in the memory but the downstream token has [element2 element1], since future operations may attempt to retract something using the former ordering, but fail to actually retract anything since the downstream tokens have another ordering.  Note that while rules need to accept any ordering the engine uses, accumulator results will not necessarily be equal (and in the case of acc/all they won't be).

I think these are valid, but would probably merit some thought from you too and anyone else looking at this PR.

Otherwise this is fairly similar to my changes for AccumulateNode, with some additional tests added to reflect AccumulateWithJoinFilterNode specific paths and previous tests for AccumulateNode parameterized to test both nodes.  I'll note that I decided to refer to the join types rather than the node names in the parameterization, since on further thought referring to node types in the tests seemed like unnecessary brittleness of test comments and descriptions.  I think my previous pattern of referring to the concrete node types was a mistake.

1. https://github.com/rbrush/clara-rules/blob/0.11.1/src/main/clojure/clara/rules/memory.cljc#L125
2. https://github.com/clojure/clojure/blob/clojure-1.8.0/src/clj/clojure/core.clj#L2888
3. https://github.com/clojure/clojure/blob/clojure-1.8.0/src/clj/clojure/core.clj#L2795