### PR TITLE
- identical checks before equals for token/activation retraction in l…

### DIFF
--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -14,7 +14,9 @@
 (defrecord Accumulator [input-condition initial-value reduce-fn combine-fn convert-return-fn])
 
 ;; A Rete-style token, which contains two items:
-;; * matches, a sequence of [fact, node-id] tuples for the facts and corresponding nodes they matched.
+;; * matches, a vector of [fact, node-id] tuples for the facts and corresponding nodes they matched.
+;; NOTE:  It is important that this remains an indexed vector for memory optimizations as well as
+;;        for correct conj behavior for new elements i.e. added to the end.
 ;; * bindings, a map of keyword-to-values for bound variables.
 (defrecord Token [matches bindings])
 


### PR DESCRIPTION
The changes here are described in https://github.com/rbrush/clara-rules/issues/213.

Some implementation notes:

* I did a lot of small tuning details as far as type-hinting and removing some indirection or abstraction layers typically taken by Clojure.  I was profiling these heavy data scenarios closely and these type hints and lower-level interface calls etc, definitely pay off in a significant way.  I'd not want to do this sort of work everywhere, but in this particular hot spot of code, I think it is advantageous to squeeze out all the performance as we can.  The workflow I'm looking at now needs to be performing in sub-second-like time, so these details matter.

* I did not make changes to how Element's are compared for equality here.  I did a demo run of that and didn't see as much of a payoff.  It may still be worthwhile, but I wanted to hold off on that until a separate issue if I find it to have some real value.

* clara.rules.memory namespace is indeed getting a little cluttered between the `:clj` and `:cljs` read-conditionals being used.  The functions towards the top that are only for `:clj` could certainly be pulled out to a new namespace.  I think this reorganization should be a separate issue though.