### PR TITLE
Revised durability

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [prismatic/schema "1.0.1"]]
-  :profiles {:dev {:dependencies [[org.clojure/math.combinatorics "0.1.3"]]}
+  :profiles {:dev {:dependencies [[org.clojure/math.combinatorics "0.1.3"]
+                                  [org.clojure/data.fressian "0.2.1"]]}
              :provided {:dependencies [[org.clojure/clojurescript "1.7.170"]]}}
   :plugins [[lein-codox "0.9.0" :exclusions [org.clojure/clojure]]
             [lein-javadoc "0.2.0" :exclusions [org.clojure/clojure]]

--- a/src/main/clojure/clara/rules/compiler.clj
+++ b/src/main/clojure/clara/rules/compiler.clj
@@ -14,19 +14,42 @@
             [clojure.walk :as walk]
             [schema.core :as sc]
             [schema.macros :as sm])
-
-  (:import [clara.rules.engine ProductionNode QueryNode HashJoinNode ExpressionJoinNode
-            NegationNode TestNode AccumulateNode AlphaNode LocalTransport
-            LocalSession Accumulator]
-           [java.beans PropertyDescriptor]))
+  (:import [clara.rules.engine
+            ProductionNode
+            QueryNode
+            AlphaNode
+            RootJoinNode
+            HashJoinNode
+            ExpressionJoinNode
+            NegationNode
+            NegationWithJoinFilterNode
+            TestNode
+            AccumulateNode
+            AccumulateWithJoinFilterNode
+            LocalTransport
+            LocalSession
+            Accumulator]
+           [java.beans
+            PropertyDescriptor]))
 
 ;; Protocol for loading rules from some arbitrary source.
 (defprotocol IRuleSource
   (load-rules [source]))
 
-;; These nodes exist in the beta network.
-(def BetaNode (sc/either ProductionNode QueryNode HashJoinNode ExpressionJoinNode
-                         NegationNode TestNode AccumulateNode))
+(sc/defschema BetaNode
+  "These nodes exist in the beta network."
+  (sc/pred (comp #{ProductionNode
+                   QueryNode
+                   RootJoinNode
+                   HashJoinNode
+                   ExpressionJoinNode
+                   NegationNode
+                   NegationWithJoinFilterNode
+                   TestNode
+                   AccumulateNode
+                   AccumulateWithJoinFilterNode}
+                 class)
+           "Some beta node type"))
 
 ;; A rulebase -- essentially an immutable Rete network with a collection of
 ;; alpha and beta nodes and supporting structure.
@@ -182,7 +205,7 @@
 
 (def ^:dynamic *compile-ctx* nil)
 
-(defn- try-eval
+(defn try-eval
   "Evals the given `expr`.  If an exception is thrown, it is caught and an
    ex-info exception is thrown with more details added.  Uses *compile-ctx*
    for additional contextual info to add to the exception details."
@@ -1177,22 +1200,26 @@
          condition
          children
          join-bindings)
+        
         ;; If the join operation includes arbitrary expressions
         ;; that can't expressed as a hash join, we must use the expressions
         (if (:join-filter-expressions beta-node)
-          (eng/->ExpressionJoinNode
-           id
-           condition
-           (binding [*compile-ctx* {:condition condition
-                                    :join-filter-expressions (:join-filter-expressions beta-node)
-                                    :env (:env beta-node)
-                                    :msg "compiling expression join node"}]
-             (compile-expr id
-                           (compile-join-filter (:join-filter-expressions beta-node)
-                                                (:join-filter-join-bindings beta-node)
-                                                (:env beta-node))))
-           children
-           join-bindings)
+          (let [join-filter-expr (compile-join-filter (:join-filter-expressions beta-node)
+                                                      (:join-filter-join-bindings beta-node)
+                                                      (:env beta-node))]
+            (with-meta
+              (eng/->ExpressionJoinNode
+               id
+               condition
+               (binding [*compile-ctx* {:condition condition
+                                        :join-filter-expressions (:join-filter-expressions beta-node)
+                                        :env (:env beta-node)
+                                        :msg "compiling expression join node"}]
+                 (compile-expr id
+                               join-filter-expr))
+               children
+               join-bindings)
+              {:join-filter-expr join-filter-expr}))
           (eng/->HashJoinNode
            id
            condition
@@ -1205,19 +1232,22 @@
       ;; and use the appropriate node type.
       (if (:join-filter-expressions beta-node)
 
-        (eng/->NegationWithJoinFilterNode
-         id
-         condition
-         (binding [*compile-ctx* {:condition condition
-                                  :join-filter-expressions (:join-filter-expressions beta-node)
-                                  :env (:env beta-node)
-                                  :msg "compiling negation with join filter node"}]
-           (compile-expr id
-                         (compile-join-filter (:join-filter-expressions beta-node)
-                                              (:join-filter-join-bindings beta-node)
-                                              (:env beta-node))))
-         children
-         join-bindings)
+        (let [join-filter-expr (compile-join-filter (:join-filter-expressions beta-node)
+                                                    (:join-filter-join-bindings beta-node)
+                                                    (:env beta-node))]
+          (with-meta
+            (eng/->NegationWithJoinFilterNode
+             id
+             condition
+             (binding [*compile-ctx* {:condition condition
+                                      :join-filter-expressions (:join-filter-expressions beta-node)
+                                      :env (:env beta-node)
+                                      :msg "compiling negation with join filter node"}]
+               (compile-expr id
+                             join-filter-expr))
+             children
+             join-bindings)
+            {:join-filter-expr join-filter-expr}))
 
         (eng/->NegationNode
          id
@@ -1226,24 +1256,28 @@
          join-bindings))
 
       :test
-      (eng/->TestNode
-       id
-       (binding [*compile-ctx* {:condition condition
-                                :env (:env beta-node)
-                                :msg "compiling test node"}]
-         (compile-expr id
-                       (compile-test (:constraints condition))))
-       children)
+      (let [test-expr (compile-test (:constraints condition))]
+        (with-meta
+          (eng/->TestNode
+           id
+           (binding [*compile-ctx* {:condition condition
+                                    :env (:env beta-node)
+                                    :msg "compiling test node"}]
+             (compile-expr id
+                           test-expr))
+           children)
+          {:test-expr test-expr}))
 
       :accumulator
       ;; We create an accumulator that accepts the environment for the beta node
       ;; into its context, hence the function with the given environment.
-      (let [compiled-node (binding [*compile-ctx* {:condition condition
+      (let [accum-expr (compile-accum (:accumulator beta-node) (:env beta-node))
+            compiled-node (binding [*compile-ctx* {:condition condition
                                                    :accumulator (:accumulator beta-node)
                                                    :env (:env beta-node)
                                                    :msg "compiling accumulator"}]
                             (compile-expr id
-                                          (compile-accum (:accumulator beta-node) (:env beta-node))))
+                                          accum-expr))
             compiled-accum (compiled-node (:env beta-node))]
 
         ;; Ensure the compiled accumulator has the expected structure
@@ -1255,54 +1289,63 @@
 
         (if (:join-filter-expressions beta-node)
 
-          (eng/->AccumulateWithJoinFilterNode
-           id
-           ;; Create an accumulator structure for use when examining the node or the tokens
-           ;; it produces.
-           {:accumulator (:accumulator beta-node)
-            ;; Include the original filter expressions in the constraints for inspection tooling.
-            :from (update-in condition [:constraints]
-                             into (-> beta-node :join-filter-expressions :constraints))}
-           compiled-accum
-           (binding [*compile-ctx* {:condition condition
-                                    :join-filter-expressions (:join-filter-expressions beta-node)
-                                    :env (:env beta-node)
-                                    :msg "compiling accumulate with join filter node"}]
-             (compile-expr id
-                           (compile-join-filter (:join-filter-expressions beta-node)
-                                                (:join-filter-join-bindings beta-node)
-                                                (:env beta-node))))
-           (:result-binding beta-node)
-           children
-           join-bindings
-           (:new-bindings beta-node))
+          (let [join-filter-expr (compile-join-filter (:join-filter-expressions beta-node)
+                                                      (:join-filter-join-bindings beta-node)
+                                                      (:env beta-node))]
+            (with-meta
+              (eng/->AccumulateWithJoinFilterNode
+               id
+               ;; Create an accumulator structure for use when examining the node or the tokens
+               ;; it produces.
+               {:accumulator (:accumulator beta-node)
+                ;; Include the original filter expressions in the constraints for inspection tooling.
+                :from (update-in condition [:constraints]
+                                 into (-> beta-node :join-filter-expressions :constraints))}
+               compiled-accum
+               (binding [*compile-ctx* {:condition condition
+                                        :join-filter-expressions (:join-filter-expressions beta-node)
+                                        :env (:env beta-node)
+                                        :msg "compiling accumulate with join filter node"}]
+                 (compile-expr id
+                               join-filter-expr))
+               (:result-binding beta-node)
+               children
+               join-bindings
+               (:new-bindings beta-node))
+              {:accum-expr accum-expr
+               :join-filter-expr join-filter-expr}))
 
           ;; All unification is based on equality, so just use the simple accumulate node.
-          (eng/->AccumulateNode
-           id
-           ;; Create an accumulator structure for use when examining the node or the tokens
-           ;; it produces.
-           {:accumulator (:accumulator beta-node)
-            :from condition}
-           compiled-accum
-           (:result-binding beta-node)
-           children
-           join-bindings
-           (:new-bindings beta-node))))
+          (with-meta
+            (eng/->AccumulateNode
+             id
+             ;; Create an accumulator structure for use when examining the node or the tokens
+             ;; it produces.
+             {:accumulator (:accumulator beta-node)
+              :from condition}
+             compiled-accum
+             (:result-binding beta-node)
+             children
+             join-bindings
+             (:new-bindings beta-node))
+            {:accum-expr accum-expr})))
 
       :production
-      (eng/->ProductionNode
-       id
-       production
-       (with-bindings (cond-> {#'*file* (-> production :rhs meta :file)
-                               #'*compile-ctx* {:production production
-                                                :msg "compiling production node"}}
-                        (:ns-name production) (assoc #'*ns* (the-ns (:ns-name production))))
-         (compile-expr id
-                       (with-meta (compile-action (:bindings beta-node)
-                                                  (:rhs production)
-                                                  (:env production))
-                         (meta (:rhs production))))))
+      (let [action-expr (with-meta (compile-action (:bindings beta-node)
+                                                   (:rhs production)
+                                                   (:env production))
+                          (meta (:rhs production)))]
+        (with-meta
+          (eng/->ProductionNode
+           id
+           production
+           (with-bindings (cond-> {#'*file* (-> production :rhs meta :file)
+                                   #'*compile-ctx* {:production production
+                                                    :msg "compiling production node"}}
+                            (:ns-name production) (assoc #'*ns* (the-ns (:ns-name production))))
+             (compile-expr id
+                           action-expr)))
+          {:action-expr action-expr}))
 
       :query
       (eng/->QueryNode
@@ -1421,19 +1464,22 @@
   [alpha-nodes :- [schema/AlphaNode]]
   (for [{:keys [condition beta-children env]} alpha-nodes
         :let [{:keys [type constraints fact-binding args]} condition
-              cmeta (meta condition)]]
+              cmeta (meta condition)
+              alpha-expr (with-meta (compile-condition
+                                     type (first args)  constraints
+                                     fact-binding env)
+                           (meta condition))]]
 
-    (cond-> {:type (effective-type type)
-             :alpha-fn (binding [*file* (or (:file cmeta) *file*)
-                                 *compile-ctx* {:condition condition
-                                                :env env
-                                                :msg "compiling alpha node"}]
-                         (try-eval (with-meta (compile-condition
-                                               type (first args)  constraints
-                                               fact-binding env)
-                                     (meta condition))))
-             :children beta-children}
-      env (assoc :env env))))
+    (with-meta
+      (cond-> {:type (effective-type type)
+               :alpha-fn (binding [*file* (or (:file cmeta) *file*)
+                                   *compile-ctx* {:condition condition
+                                                  :env env
+                                                  :msg "compiling alpha node"}]
+                           (try-eval alpha-expr))
+               :children beta-children}
+        env (assoc :env env))
+      {:alpha-expr alpha-expr})))
 
 (sc/defn build-network
   "Constructs the network from compiled beta tree and condition functions."
@@ -1460,9 +1506,11 @@
                              entry))
 
         ;; type, alpha node tuples.
-        alpha-nodes (for [{:keys [type alpha-fn children env]} alpha-fns
+        alpha-nodes (for [{:keys [type alpha-fn children env] :as alpha-map} alpha-fns
                           :let [beta-children (map id-to-node children)]]
-                      [type (eng/->AlphaNode env beta-children alpha-fn)])
+                      [type (with-meta
+                              (eng/->AlphaNode env beta-children alpha-fn)
+                              {:alpha-expr (:alpha-expr (meta alpha-map))})])
 
         ;; Merge the alpha nodes into a multi-map
         alpha-map (reduce
@@ -1540,6 +1588,10 @@
   []
   (reset! session-cache {}))
 
+(defn production-load-order-comp [a b]
+  (< (-> a meta ::rule-load-order)
+     (-> b meta ::rule-load-order)))
+
 (sc/defn mk-session*
   "Compile the rules into a rete network and return the given session."
   [productions :- #{schema/Production}
@@ -1553,10 +1605,10 @@
         ;;
         ;; Note that this ordering is not for correctness; we are just trying to increase consistency of rulebase compilation,
         ;; and hopefully thereby execution times, from run to run.
-        productions (into (sorted-set-by (fn [a b]
-                                           (< (-> a meta ::rule-load-order)
-                                              (-> b meta ::rule-load-order))))
-                          productions)
+        productions (with-meta (into (sorted-set-by production-load-order-comp)
+                                     productions)
+                      ;; Store the name of the custom comparator for durability.
+                      {:clara.rules.durability/comparator-name `production-load-order-comp})
         beta-graph (to-beta-graph productions)
         beta-tree (compile-beta-graph beta-graph)
         beta-root-ids (-> beta-graph :forward-edges (get 0)) ; 0 is the id of the virtual root node.

--- a/src/main/clojure/clara/rules/durability.clj
+++ b/src/main/clojure/clara/rules/durability.clj
@@ -1,159 +1,623 @@
 (ns clara.rules.durability
-  "Experimental namespace. This may change non-passively without warning.
+  "Support for persisting Clara sessions to an external store.
+   Provides the ability to store and restore an entire session working memory state.  The restored
+   session is able to have additional insert, retract, query, and fire rule calls performed 
+   immediately after.
 
-   Support for persisting Clara sessions to an external store. This will have two models: obtaining the full
-   state of a session, and obtaining a \"diff\" of changes from a previous state.
+   See https://github.com/rbrush/clara-rules/issues/198 for more discussion on this.
 
-   See the session-state function to retrieve the full state of a session as a data structure that can
-   be easily serialized via EDN or Fressian. Sessions can then be recovered with the restore-session-state function.
-
-   TODO: diff support is pending -- functions for obtaining a diff of state from a previous point, allowing for a write-ahead log."
-  (:require [clara.rules :refer :all]
-            [clara.rules.listener :as l]
-            [clara.rules.engine :as eng]
+   Note! This is still an EXPERIMENTAL namespace. This may change non-passively without warning.
+   Any session or rulebase serialized in one version of Clara is not guaranteed to deserialize 
+   successfully against another version of Clara."
+  (:require [clara.rules.engine :as eng]
+            [clara.rules.compiler :as com]
             [clara.rules.memory :as mem]
             [clojure.set :as set]
-            [schema.core :as s]
-            [schema.macros :as sm])
+            [schema.core :as s])
+  (:import [clara.rules.compiler
+            Rulebase]
+           [clara.rules.memory
+            RuleOrderedActivation]
+           [java.util
+            List
+            Map
+            IdentityHashMap]))
 
-  (:import [clara.rules.engine ExpressionJoinNode HashJoinNode RootJoinNode Token AccumulateNode ProductionNode]))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Rulebase serialization helpers.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(def ^:dynamic *node-id->node-cache*
+  "Useful for caching rulebase network nodes by id during serialization and deserialization to
+   avoid creating multiple object instances for the same node."
+  nil)
 
-;; A schema representing a minimal representation of a rule session's state.
-;; This allows for efficient storage, particularly when serialized with Fressian or a similar format
-;; to eliminate redundnacy.
-(def session-state-schema
-  {
-   ;; Map of matching facts to the number of them that matched.
-   :fact-counts {s/Any s/Int}
+(def ^:dynamic *compile-expr-fn*
+  "Similar to what is done in clara.rules.compiler, this is a function used to compile
+   expressions used in nodes of the rulebase network.  A common function would cache
+   evaluated expressions by node-id and expression form to avoid duplicate evalutation
+   of the same expressions."
+  nil)
 
-   ;; Map of node IDs to tokens indicating a pending rule activation.
-   :activations {s/Int [Token]}
+(defn- add-node-fn [node fn-key meta-key]
+  (assoc node
+         fn-key
+         (*compile-expr-fn* (:id node) (meta-key (meta node)))))
 
-   ;; Map of accumulator node IDs to accumulated results.
-   :accum-results {s/Int [{:join-bindings {s/Keyword s/Any} :fact-bindings {s/Keyword s/Any} :result s/Any}]}
+(defn add-rhs-fn [node]
+  ;; The RHS expression may need to be compiled within the namespace scope of specifically declared
+  ;; :ns-name.  The LHS expressions do not (currently) need or support this path.
+  ;; See https://github.com/rbrush/clara-rules/issues/178 for more details.
+  (with-bindings (if-let [ns (some-> node
+                                     :production
+                                     :ns-name
+                                     the-ns)]
+                   {#'*ns* ns}
+                   {})
+    (add-node-fn node :rhs :action-expr)))
 
-   ;; Map associating node ids and tokens with a vector of facts they had inserted. This is used
-   ;; to track truth maintenance, so if a given token is retracted, we can also retract the inferred items.
-   :insertions {[(s/one s/Int "node-id") (s/one Token "token")] [[s/Any]]}})
+(defn add-alpha-fn [node]
+  ;; AlphaNode's do not have node :id's right now since they don't
+  ;; have any memory specifically associated with them.
+  (assoc node :activation (com/try-eval (:alpha-expr (meta node)))))
 
-(s/defn session-state :- session-state-schema
-  " Returns the state of a session as an EDN- or Fressian-serializable data structure. The returned
-   structure contains only the minimal data necessary to reconstruct the session via the restore-session-state
-   function below."
-  [session]
-  (let [{:keys [rulebase memory]} (eng/components session)
-        {:keys [id-to-node production-nodes query-nodes]} rulebase
-        beta-nodes (for [[id node] id-to-node
-                         :when (or (instance? HashJoinNode node)
-                                   (instance? RootJoinNode node)
-                                   (instance? ExpressionJoinNode node))]
-                     node)
+(defn add-join-filter-fn [node]
+  (add-node-fn node :join-filter-fn :join-filter-expr))
 
-        accumulate-nodes (for [[id node] id-to-node
-                         :when (instance? AccumulateNode node)]
-                     node)
+(defn add-test-fn [node]
+  (add-node-fn node :test :test-expr))
 
-        ;; Get the counts for each beta node. Mutliple nodes may have the same facts
-        ;; but merging these is benign since the counts would also match.
-        fact-counts (reduce
-                     (fn [fact-counts beta-node]
-                       (let [facts (for [{:keys [fact]} (mem/get-elements-all memory beta-node)]
-                                     fact)]
-                         (merge fact-counts (frequencies facts))))
-                     {}
-                     beta-nodes)
+(defn add-accumulator [node]
+  (assoc node
+         :accumulator ((*compile-expr-fn* (:id node)
+                                          (:accum-expr (meta node)))
+                       (:env node))))
 
-        activations (->> (for [{:keys [node token]} (mem/get-activations memory)]
-                           {(:id node) [token]})
-                         (apply merge-with concat))
+(defn node-id->node
+  "Lookup the node for the given node-id in the *node-id->node-cache* cache."
+  [node-id]
+  (@*node-id->node-cache* node-id))
 
-        accum-results (into {}
-                            (for [accum-node accumulate-nodes]
-                                 [(:id accum-node) (mem/get-accum-reduced-complete memory accum-node)]))
+(defn cache-node
+  "Cache the node in the *node-id->node-cache*.  Returns the node."
+  [node]
+  (when-let [node-id (:id node)]
+    (vswap! *node-id->node-cache* assoc node-id node))
+  node)
 
-        insertions (into {}
-                         (for [[id node] id-to-node
-                               :when (instance? ProductionNode node)
-                               token (keys (mem/get-insertions-all memory node))]
-                           [[(:id node) token] (mem/get-insertions memory node token)] ))]
+(def ^:dynamic *clj-record-holder*
+  "A cache for writing and reading Clojure records.  At write time, an IdentityHashMap can be
+   used to keep track of repeated references to the same record object instance occurring in
+   the serialization stream.  At read time, a plain ArrayList (mutable and indexed for speed)
+   can be used to add records to when they are first seen, then look up repeated occurrences
+   of references to the same record instance later."
+  nil)
 
-    {:fact-counts fact-counts
-     :activations (or activations {})
-     :accum-results (or accum-results {})
-     :insertions insertions}))
+(defn clj-record-fact->idx
+  "Gets the numeric index for the given fact from the *clj-record-holder*."
+  [fact]
+  (.get ^Map *clj-record-holder* fact))
 
-(defn- restore-activations
-  "Restores the activations to the given session."
-  [session {:keys [activations] :as session-state}]
-  (let [{:keys [memory rulebase] :as components} (eng/components session)
-        {:keys [production-nodes id-to-node]} rulebase
+(defn clj-record-holder-add-fact-idx!
+  "Adds the fact to the *clj-record-holder* with a new index.  This can later be retrieved
+   with clj-record-fact->idx."
+  [fact]
+  ;; Note the values will be int type here.  This shouldn't be a problem since they
+  ;; will be read later as longs and both will be compatible with the index lookup
+  ;; at read-time.  This could have a cast to long here, but it would waste time
+  ;; unnecessarily.
+  (.put ^Map *clj-record-holder* fact (.size ^Map *clj-record-holder*)))
 
-        restored-activations (for [[node-id tokens] activations
-                                   token tokens]
-                               (eng/->Activation (id-to-node node-id) token))
+(defn clj-record-idx->fact
+  "The reverse of clj-record-fact->idx.  Returns a fact for the given index found
+   in *clj-record-holder*."
+  [id]
+  (.get ^List *clj-record-holder* id))
 
-        grouped-by-production (group-by (fn [activation]
-                                          (-> activation :node :production)) restored-activations)
+(defn clj-record-holder-add-fact!
+  "The reverse of clj-record-holder-add-fact-idx!.  Adds the fact to the *clj-record-holder*
+   at the next available index."
+  [fact]
+  (.add ^List *clj-record-holder* fact)
+  fact)
 
-        transient-memory (doto (mem/to-transient memory)
-                           (mem/clear-activations!))]
+(defn create-map-entry
+  "Helper to create map entries.  This can be useful for serialization implementations
+   on clojure.lang.MapEntry types.
+   Using the ctor instead of clojure.lang.MapEntry/create since this method
+   doesn't exist prior to clj 1.8.0"
+  [k v]
+  (clojure.lang.MapEntry. k v))
 
-    (doseq [[production activations] grouped-by-production]
+;;;; To deal with http://dev.clojure.org/jira/browse/CLJ-1733 we need to impl a way to serialize
+;;;; sorted sets and maps.  However, this is not sufficient for arbitrary comparators.  If
+;;;; arbitrary comparators are used for the sorted coll, the comparator has to be restored
+;;;; explicitly since arbitrary functions are not serializable in any stable way right now.
 
-      (mem/add-activations! transient-memory production activations))
+(defn sorted-comparator-name
+  "Sorted collections are not easily serializable since they have an opaque function object instance
+   associated with them.  To deal with that, the sorted collection can provide a ::comparator-name 
+   in the metadata that indicates a symbolic name for the function used as the comparator.  With this
+   name the function can be looked up and associated to the sorted collection again during
+   deserialization time.
+   * If the sorted collection has metadata ::comparator-name, then the value should be a name 
+   symbol and is returned.  
+   * If the sorted collection has the clojure.lang.RT/DEFAULT_COMPARATOR, returns nil.
+   * If neither of the above are true, an exception is thrown indicating that there is no way to provide
+   a useful name for this sorted collection, so it won't be able to be serialized."
+  [^clojure.lang.Sorted s]
+  (let [cname (-> s meta ::comparator-name)]
 
-    ;; Create a new session with the given activations.
-    (eng/assemble (assoc components :memory (mem/to-persistent! transient-memory)))))
+    ;; Fail if reliable serialization of this sorted coll isn't possible.
+    (when (and (not cname)
+               (not= (.comparator s) clojure.lang.RT/DEFAULT_COMPARATOR))
+      (throw (ex-info (str "Cannot serialize sorted collection with non-default"
+                           " comparator because no :clara.rules.durability/comparator-name provided in metadata.")
+                      {:sorted-coll s
+                       :comparator (.comparator s)})))
 
-(defn- restore-accum-results
-  [session {:keys [accum-results] :as session-state}]
-  (let [{:keys [memory rulebase transport] :as components} (eng/components session)
-        id-to-node (:id-to-node rulebase)
-        transient-memory (mem/to-transient memory)]
+    cname))
 
-    ;; Add the results to the accumulator node.
-    (doseq [[id results] accum-results
-            {:keys [join-bindings fact-bindings result]} results]
+(defn seq->sorted-set
+  "Helper to create a sorted set from a seq given an optional comparator."
+  [s ^java.util.Comparator c]
+  (if c
+    (clojure.lang.PersistentTreeSet/create c (seq s))
+    (clojure.lang.PersistentTreeSet/create (seq s))))
 
-      (eng/right-activate-reduced (id-to-node id)
-                                  join-bindings
-                                  [[fact-bindings (first result)]]
-                                  transient-memory
-                                  transport
-                                  (l/to-transient l/default-listener)))
+(defn seq->sorted-map
+  "Helper to create a sorted map from a seq given an optional comparator."
+  [s ^java.util.Comparator c]
+  (if c
+    (clojure.lang.PersistentTreeMap/create c ^clojure.lang.ISeq (sequence cat s))
+    (clojure.lang.PersistentTreeMap/create ^clojure.lang.ISeq (sequence cat s))))
 
-    (eng/assemble (assoc components :memory (mem/to-persistent! transient-memory)))))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Memory serialization via "indexing" working memory facts.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- restore-insertions
-  [session {:keys [insertions] :as session-state}]
-  (let [{:keys [memory rulebase transport] :as components} (eng/components session)
-        id-to-node (:id-to-node rulebase)
-        transient-memory (mem/to-transient memory)]
+;;; A placeholder to put in working memory locations where consumer-defined, domain-specific facts
+;;; were stored at.  This placeholder is used to track the position of a fact so that the fact can
+;;; be serialized externally by IWorkingMemorySerializer and later the deserialized fact can be put
+;;; back in place of this placeholder.
+;;; See the ISessionSerializer and IWorkingMemorySerializer protocols and
+;;; indexed-session-memory-state for more details.
+(defrecord MemIdx [idx])
 
-    ;; Add the results to the accumulator node.
-    (doseq [[[id token] inserted-facts] insertions
-            insertion-group inserted-facts]
-      ;; Each insertion group represents a distinct activation of the ProductionNode.
-      (mem/add-insertions! transient-memory (id-to-node id) token insertion-group))
+(defn find-index
+  "Finds the fact in the fact->index-map.  The fact is assumed to be a key.  Returns the value for
+   that key, which should just be a numeric index used to track where facts are stubbed out with
+   MemIdx's in working memory so that they can be 'put back' later."
+  [^java.util.Map fact->index-map fact]
+  (.get fact->index-map fact))
 
-    (eng/assemble (assoc components :memory (mem/to-persistent! transient-memory)))))
+(defn- find-index-or-add!
+  "The same as find-index, but if the fact is not found, it is added to the map (destructively)
+   and the index it was mapped to is returned.
+   This implies that the map must support the mutable map interface, namely java.util.Map.put()."
+  [^java.util.Map fact->index-map fact]
+  (or (.get fact->index-map fact)
+      (let [n (.size fact->index-map)
+            idx (->MemIdx n)]
+        (.put fact->index-map fact idx)
+        idx)))
 
-(s/defn restore-session-state
-  " Restore the given session to have the provided session state. The given session should be
-   a newly-created session that was created with the same parameters as the session that was
-   serialized. For instance, it should use the same rulesets, type function, and other settings.
+;;; Similar what is in clara.rules.memory currently, but just copied for now to avoid dependency issues.
+(defn- update-vals [m update-fn]
+  (->> m
+       (reduce-kv (fn [m k v]
+                    (assoc! m k (update-fn v)))
+                  (transient {}))
+       persistent!))
 
-   This function returns a new session instance that reflects the given saved state.  The returned
-   session should be indistinguishable from the session that had its state saved."
-  [session
-   {:keys [fact-counts] :as session-state} :- session-state-schema]
-  (let [fact-seq (for [[fact count] fact-counts
-                       i (range count)]
-                   fact)]
+(defn- index-bindings
+  [seen bindings]
+  (update-vals bindings
+               #(find-index-or-add! seen %)))
 
-    (-> session
-        (insert-all fact-seq)
-        (restore-activations session-state)
-        (restore-accum-results session-state)
-        (restore-insertions session-state))))
+(defn- index-update-bindings-keys [index-update-bindings-fn
+                                   bindings-map]
+  (persistent!
+   (reduce-kv (fn [m k v]
+                (assoc! m
+                        (index-update-bindings-fn k)
+                        v))
+              (transient {})
+              bindings-map)))
+
+(defn- index-token [seen token]
+  (-> token
+      (update :matches
+              #(mapv (fn [[fact node-id]]
+                       [(find-index-or-add! seen fact)
+                        node-id])
+                     %))
+      (update :bindings
+              #(index-bindings seen %))))
+
+(defn index-alpha-memory [seen amem]
+  (let [index-update-bindings-fn #(index-bindings seen %)
+        index-update-elements (fn [elements]
+                                (mapv (fn [elem]
+                                        (-> elem
+                                            (update :fact
+                                                    #(find-index-or-add! seen %))
+                                            (update :bindings
+                                                    index-update-bindings-fn)))
+                                      elements))]
+    (update-vals amem
+                 #(-> (index-update-bindings-keys index-update-bindings-fn %)
+                      (update-vals index-update-elements)))))
+
+(defn index-accum-memory [seen accum-mem]
+  (let [index-update-bindings-fn #(index-bindings seen %)
+        index-facts (fn [facts]
+                      (mapv #(find-index-or-add! seen %) facts))
+        index-update-accum-reduced (fn [node-id accum-reduced]
+                                     (let [m (meta accum-reduced)]
+                                       (if (::eng/accum-node m)
+                                         ;; AccumulateNode
+                                         (let [[facts res] accum-reduced
+                                               facts (index-facts facts)]
+                                           (with-meta
+                                             [facts
+                                              (if (= ::eng/not-reduced res)
+                                                res
+                                                (find-index-or-add! seen res))]
+                                             m))
+
+                                         ;; AccumulateWithJoinFilterNode
+                                         (with-meta (index-facts accum-reduced)
+                                           m))))
+        index-update-bindings-map (fn [node-id bindings-map]
+                                    (-> (index-update-bindings-keys index-update-bindings-fn bindings-map)
+                                        (update-vals #(index-update-accum-reduced node-id %))))]
+
+    (->> accum-mem
+         (reduce-kv (fn [m node-id bindings-map]
+                      (assoc! m node-id (-> (index-update-bindings-keys index-update-bindings-fn bindings-map)
+                                            (update-vals #(index-update-bindings-map node-id %)))))
+                    (transient {}))
+         persistent!)))
+
+(defn index-beta-memory [seen bmem]
+  (let [index-update-tokens (fn [tokens]
+                              (mapv #(index-token seen %) tokens))]
+    (update-vals bmem
+                 (fn [v]
+                   (-> (index-update-bindings-keys #(index-bindings seen %) v)
+                       (update-vals index-update-tokens))))))
+
+(defn index-production-memory [seen pmem]
+  (let [index-update-facts (fn [facts]
+                             (mapv #(or (find-index seen %)
+                                        (find-index-or-add! seen %))
+                                   facts))]
+    (update-vals pmem
+                 (fn [token-map]
+                   (->> token-map
+                        (reduce-kv (fn [m k v]
+                                     (assoc! m
+                                             (index-token seen k)
+                                             (mapv index-update-facts v)))
+                                   (transient {}))
+                        persistent!)))))
+
+(defn index-activation-map [seen actmap]
+  (update-vals actmap
+               #(mapv (fn [^RuleOrderedActivation act]
+                        (mem/->RuleOrderedActivation (.-node-id act)
+                                                     (index-token seen (.-token act))
+                                                     (.-activation act)
+                                                     (.-rule-load-order act)))
+                      %)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Commonly useful session serialization helpers.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def ^:dynamic *mem-facts*
+  "Useful for ISessionSerializer implementors to have a reference to the facts deserialized via 
+   IWorkingMemorySerializer that are needed to restore working memory whose locations were stubbed
+   with a MemIdx during serialization."
+  nil)
+
+(defn find-mem-idx
+  "Finds the fact from *mem-facts* at the given index.  See docs on *mem-facts* for more."
+  [idx]
+  (get *mem-facts* idx))
+
+(defn indexed-session-memory-state
+  "Takes the working memory from a session and strips it down to only the memory needed for
+   serialization.  Along with this, replaces all working memory facts with MemIdx place holders.
+   The terminology being used here is to call this step 'indexing' the memory.  
+   
+   A map is returned with two keys:
+   * :memory - The working memory representation that is the same as the given memory's :memory,
+     however, all facts in the memory are replaced with MemIdx placeholders. 
+   * :indexed-facts - the facts replaced with MemIdx placeholders.  The facts are returned in a
+     sequential collection.  Each fact is the n'th item of the collection if the MemIdx for that
+     fact has :idx = n.  No facts returned should be identical? (i.e. multiple references to the
+     same object instance).  However, it is possible for some facts returned to be aggregations
+     containing other facts that do appear elsewhere in the fact sequence.  It is up to the
+     implementation of the IWorkingMemorySerializer to deal with these possible, identical? object
+     references correctly.  This is generally true for most serialization mechanisms.
+
+   Note!  This function should not typically be used.  It is left public to assist in ISessionSerializer
+          durability implementations.  Use clara.rules/mk-session typically to make rule sessions.
+
+   Note!  Currently this only supports the clara.rules.memory.PersistentLocalMemory implementation
+          of memory."
+  [memory]
+  (let [vec-indexed-facts (fn [^java.util.Map fact->index-map]
+                            ;; It is not generally safe to reduce or seq over a mutable Java Map.
+                            ;; One example is IdentityHashMap.  The iterator of the IdentityHashMap
+                            ;; mutates the map entry values in place and it is never safe to call a
+                            ;; Iterator.hasNext() when not finished working with the previous value
+                            ;; returned from Iterator.next().  This is subtle and is actually only a
+                            ;; problem in JDK6 for IdentityHashMap.  JDK7+ appear to have discontinued
+                            ;; this mutable map entry.  However, this is not something to rely on and
+                            ;; JDK6 support is still expected to work for Clara.  The only trasducer
+                            ;; in Clojure that can currently, safely consume the JDK6-style
+                            ;; IdentityHashMap via its entry set iterator is Eduction.  This doesn't
+                            ;; appear to be due to explicit semantics though, but rather an
+                            ;; implementation detail.
+                            ;; For further context, this situation is related, but not exactly the
+                            ;; same as http://dev.clojure.org/jira/browse/CLJ-1738.
+                            (let [;; The use of a primitive array here isn't strictly necessary.  However,
+                                  ;; it doesn't add much in terms of complexity and is faster than the
+                                  ;; alternatives.
+                                  ^"[Ljava.lang.Object;" arr (make-array Object (.size fact->index-map))
+                                  es (.entrySet fact->index-map)
+                                  it (.iterator es)]
+                              (when (.hasNext it)
+                                (loop [^java.util.Map$Entry e (.next it)]
+                                  (aset arr (:idx (.getValue e)) ^Object (.getKey e))
+                                  (when (.hasNext it)
+                                    (recur (.next it)))))
+                              (into [] arr)))
+
+        index-memory (fn [memory]
+                       (let [seen (java.util.IdentityHashMap.)
+
+                             indexed (-> memory
+                                         (update :accum-memory #(index-accum-memory seen %))
+                                         (update :alpha-memory #(index-alpha-memory seen %))
+                                         (update :beta-memory #(index-beta-memory seen %))
+                                         (update :production-memory #(index-production-memory seen %))
+                                         (update :activation-map #(index-activation-map seen %)))]
+
+                         {:memory indexed
+                          :indexed-facts (vec-indexed-facts seen)}))]
+    (-> memory
+        index-memory
+        (update :memory
+                dissoc
+                ;; The rulebase does need to be stored per memory.  It will be restored during deserialization.
+                :rulebase
+                ;; Currently these do not support serialization and must be provided during deserialization via a
+                ;; base-session or they default to the standard defaults.
+                :activation-group-sort-fn
+                :activation-group-fn
+                :alphas-fn))))
+
+(defn create-default-get-alphas-fn [rulebase]
+  (@#'com/create-get-alphas-fn type ancestors rulebase))
+
+(defn assemble-restored-session
+  "Builds a Clara session from the given rulebase and memory components.
+   Note!  This function should not typically be used.  It is left public to assist in ISessionSerializer 
+          durability implementations.  Use clara.rules/mk-session typically to make rule sessions.
+   
+   Options can be provided via opts.
+   These include:
+
+   * :activation-group-sort-fn 
+   * :activation-group-fn
+   * :get-alphas-fn 
+
+   If the options are not provided, they will default to the Clara session defaults.
+   These are all described in detail in clara.rules/mk-session docs.
+
+   Note!  Currently this only supports the clara.rules.memory.PersistentLocalMemory implementation
+          of memory."
+  [rulebase memory opts]
+  (let [opts (-> opts
+                 (assoc :rulebase rulebase)
+                 ;; Right now activation fns do not serialize.
+                 (update :activation-group-sort-fn
+                         #(eng/options->activation-group-sort-fn {:activation-group-sort-fn %}))
+                 (update :activation-group-fn
+                         #(eng/options->activation-group-fn {:activation-group-fn %}))
+                 ;; TODO: Memory doesn't seem to ever need this or use it.  Can we just remove it from memory?
+                 (update :get-alphas-fn
+                         #(or % (create-default-get-alphas-fn rulebase))))
+
+        {:keys [listeners transport get-alphas-fn]} opts
+        
+        memory-opts (select-keys opts
+                                 #{:rulebase
+                                   :activation-group-sort-fn
+                                   :activation-group-fn
+                                   :get-alphas-fn})
+
+        transport (or transport (clara.rules.engine.LocalTransport.))
+        listeners (or listeners [])
+
+        memory (-> memory
+                   (merge memory-opts)
+                   ;; Naming difference for some reason.
+                   (set/rename-keys {:get-alphas-fn :alphas-fn})
+                   mem/map->PersistentLocalMemory)]
+    
+    (eng/assemble {:rulebase rulebase
+                   :memory memory
+                   :transport transport
+                   :listeners listeners
+                   :get-alphas-fn get-alphas-fn})))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Serialization protocols.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defprotocol ISessionSerializer
+  "Provides the ability to serialize and deserialize a session.  Options can be given and supported
+   via the opts argument to both serialize and deserialize.  Certain options are expected and 
+   required to be supported by any implementation of ISessionSerializer.  These are referred to as 
+   the 'standard' options. 
+   
+   These include:
+
+   * :rulebase-only? - When true indicates the rulebase is the only part of the session to serializer.
+     The *default* is false for the serialize-session-state function.  It is defaulted to true for the
+     serialize-rulebase convenience function.  This is useful for when many sessions are to be
+     serialized, but all having a common rulebase.  Storing the rulebase only, will likely save both
+     space and time in these scenarios.
+
+   * :with-rulebase? - When true the rulebase is included in the serialized state of the session.  
+     The *default* behavior is false when serializing a session via the serialize-session-state function.
+
+   * :base-rulebase - A rulebase to attach to the session being deserialized.  The assumption here is that
+     the session was serialized without the rulebase, i.e. :with-rulebase? = false, so it needs a rulebase
+     to be 'attached' back onto it to be usable.
+
+   Other options can be supported by specific implementors of ISessionSerializer."
+
+  (serialize [this session opts]
+    "Serialize the given session with the given options.  Where the session state is stored is dependent
+     on the implementation of this instance e.g. it may store it in a known reference to an IO stream.")
+
+  (deserialize [this mem-facts opts]
+    "Deserialize the session state associated to this instance e.g. it may be coming from a known reference
+     to an IO stream.  mem-facts is a sequential collection of the working memory facts that were 
+     serialized and deserialized by an implementation of IWorkingMemorySerializer."))
+
+(defprotocol IWorkingMemorySerializer
+  "Provides the ability to serialize and deserialize the facts stored in the working memory of a session.
+   Facts can be serialized in whatever way makes sense for a given domain.  The domain of facts can vary
+   greatly from one use-case of the rules engine to the next.  So the mechanism of serializing the facts
+   in memory can vary greatly as a result of this.  Clara does not yet provide any default implementations
+   for this, but may in the future.  However, many of the handlers defined in clara.rules.durability.fressian
+   can be reused if the consumer wishes to serialize via Fressian.  See more on this in 
+   the clara.rules.durability.fressian namespace docs.
+   
+   The important part of this serialization protocol is that the facts returned from deserialize-facts are in
+   the *same order* as how they were given to serialize-facts."
+  
+  (serialize-facts [this fact-seq]
+    "Serialize the given fact-seq, which is an order sequence of facts from working memory of a session.  
+     Note, as mentioned in the protocol docs, the *order* these are given is *important* and should be preserved
+     when they are returned via deserialize-facts.")
+
+  (deserialize-facts [this]
+    "Returns the facts associated to this instance deserialized in the same order that they were given
+     to serialize-facts."))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Durability API.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/defn serialize-rulebase
+  "Serialize *only* the rulebase portion of the given session.  The serialization is done by the
+   given session-serializer implementor of ISessionSerializer.  
+
+   Options can be given as an optional argument.  These are passed through to the session-serializer
+   implementation.  See the description of standard options an ISessionSerializer should provide in
+   the ISessionSerializer docs.  Also, see the specific ISessionSerializer implementation docs for 
+   any non-standard options supported/not supported.
+   See ISessionSerializer docs for more on that.
+
+   The rulebase is the stateless structure that controls the flow of productions, i.e. the 'rete'
+   rule network.  The ability to serialize only the rulebase is supported so that the rulebase can
+   be stored and retrieved a single time for potentially many sessions containing different working
+   memory data, for the same rules.  This function is only a convenience for passing the
+   :rulebase-only? true flag to the serialize-session-state function.
+   See serialize-session-state for more." 
+  ([session :- (s/protocol eng/ISession)
+    session-serializer :- (s/protocol ISessionSerializer)]
+   (serialize-rulebase session
+                       session-serializer
+                       {}))
+
+  ([session :- (s/protocol eng/ISession)
+    session-serializer :- (s/protocol ISessionSerializer)
+    opts :- {s/Any s/Any}]
+   (serialize session-serializer
+              session
+              (assoc opts :rulebase-only? true))))
+
+(s/defn deserialize-rulebase :- Rulebase
+  "Deserializes the rulebase stored via the serialize-rulebase function.  This is done via the given
+   session-serializer implementor of ISessionSerializer.
+
+   Options can be given as an optional argument.  These are passed through to the session-serializer
+   implementation.  See the description of standard options an ISessionSerializer should provide in
+   the ISessionSerializer docs.  Also, see the specific ISessionSerializer implementation docs for 
+   any non-standard options supported/not supported.
+   See ISessionSerializer docs for more on that."
+  ([session-serializer :- (s/protocol ISessionSerializer)]
+   (deserialize-rulebase session-serializer
+                         {}))
+
+  ([session-serializer :- (s/protocol ISessionSerializer)
+    opts :- {s/Any s/Any}]
+   (deserialize session-serializer
+                nil
+                (assoc opts :rulebase-only? true))))
+
+(s/defn serialize-session-state
+  "Serializes the state of the given session.  By default, this *excludes* the rulebase from being
+   serialized alongside the working memory state of the session.  The rulebase, if specified, and 
+   the working memory of the session are serialized by the session-serializer implementor of 
+   ISessionSerializer.  The memory-serializer implementor of IWorkingMemorySerializer is used to
+   serialize the actual facts stored within working memory.  
+
+   Typically, the caller can use a pre-defined default session-serializer, such as
+   clara.rules.durability.fressian/create-session-serializer.  
+   See clara.rules.durability.fressian for more specific details regarding this, including the extra
+   required dependency on Fressian notes found there.
+   The memory-facts-serializer is often a custom provided implemenation since the facts stored in
+   working memory are domain specific to the consumers' usage of the rules.
+   See the IWorkingMemorySerializer docs for more.
+
+   Options can be given as an optional argument.  These are passed through to the session-serializer
+   implementation.  See the description of standard options an ISessionSerializer should provide in
+   the ISessionSerializer docs.  Also, see the specific ISessionSerializer implementation docs for 
+   any non-standard options supported/not supported."
+  ([session :- (s/protocol eng/ISession)
+    session-serializer :- (s/protocol ISessionSerializer)
+    memory-facts-serializer :- (s/protocol IWorkingMemorySerializer)]
+   (serialize-session-state session
+                            session-serializer
+                            memory-facts-serializer
+                            {:with-rulebase? false}))
+
+  ([session :- (s/protocol eng/ISession)
+    session-serializer :- (s/protocol ISessionSerializer)
+    memory-facts-serializer :- (s/protocol IWorkingMemorySerializer)
+    opts :- {s/Any s/Any}]
+   (serialize-facts memory-facts-serializer
+                    (serialize session-serializer session opts))))
+
+(s/defn deserialize-session-state :- (s/protocol eng/ISession)
+  "Deserializes the session that was stored via the serialize-session-state function.  Similar to
+   what is described there, this uses the session-serializer implementor of ISessionSerializer to
+   deserialize the session and working memory state.  The memory-facts-serializer implementor of 
+   IWorkingMemorySerializer is used to deserialize the actual facts stored in working memory.
+
+   Options can be given as an optional argument.  These are passed through to the session-serializer
+   implementation.  See the description of standard options an ISessionSerializer should provide in
+   the ISessionSerializer docs.  Also, see the specific ISessionSerializer implementation docs for 
+   any non-standard options supported/not supported."
+  ([session-serializer :- (s/protocol ISessionSerializer)
+    memory-facts-serializer :- (s/protocol IWorkingMemorySerializer)]
+   (deserialize-session-state session-serializer
+                              memory-facts-serializer
+                              {}))
+  
+  ([session-serializer :- (s/protocol ISessionSerializer)
+    memory-facts-serializer :- (s/protocol IWorkingMemorySerializer)
+    opts :- {s/Any s/Any}]
+   (deserialize session-serializer
+                (deserialize-facts memory-facts-serializer)
+                opts)))

--- a/src/main/clojure/clara/rules/durability/fressian.clj
+++ b/src/main/clojure/clara/rules/durability/fressian.clj
@@ -1,0 +1,566 @@
+(ns clara.rules.durability.fressian
+  "A default Fressian-based implementation of d/ISessionSerializer.
+
+   Note!  Currently this only supports the clara.rules.memory.PersistentLocalMemory implementation
+          of memory."
+  (:require [clara.rules.durability :as d]
+            [clara.rules.memory :as mem]
+            [clara.rules.engine :as eng]
+            [clara.rules.compiler :as com]
+            [schema.core :as s]
+            [clojure.data.fressian :as fres]
+            [clojure.java.io :as jio]
+            [clojure.main :as cm])
+  (:import [clara.rules.durability
+            MemIdx]
+           [clara.rules.memory
+            RuleOrderedActivation]
+           [clara.rules.engine
+            Token
+            ProductionNode
+            QueryNode
+            AlphaNode
+            RootJoinNode
+            HashJoinNode
+            ExpressionJoinNode
+            NegationNode
+            NegationWithJoinFilterNode
+            TestNode
+            AccumulateNode
+            AccumulateWithJoinFilterNode]
+           [org.fressian
+            StreamingWriter
+            Writer
+            Reader
+            FressianWriter
+            FressianReader]
+           [org.fressian.handlers
+            WriteHandler
+            ReadHandler]
+           [java.util
+            ArrayList
+            IdentityHashMap]
+           [java.io
+            InputStream
+            OutputStream]))
+
+(defn record-map-constructor-name
+  "Return the 'map->' prefix, factory constructor function for a Clojure record."
+  [rec]
+  (let [class-name (-> rec class .getName)
+        idx (.lastIndexOf class-name (int \.))
+        ns-nom (.substring class-name 0 idx)
+        nom (.substring class-name (inc idx))]
+    ;; There could be some sort of cache for these based on class.  It may speed
+    ;; up serialization, but doesn't seem worth it yet.
+    (symbol (str (cm/demunge ns-nom)
+                 "/map->"
+                 (cm/demunge nom)))))
+
+(defn write-map
+  "Writes a map as Fressian with the tag 'map' and all keys cached."
+  [^Writer w m]
+  (.writeTag w "map" 1)
+  (.beginClosedList ^StreamingWriter w)
+  (reduce-kv
+   (fn [^Writer w k v]
+     (.writeObject w k true)
+     (.writeObject w v))
+   w
+   m)
+  (.endList ^StreamingWriter w))
+
+(defn write-with-meta
+  "Writes the object to the writer under the given tag.  If the record has metadata, the metadata
+   will also be written.  read-with-meta will associated this metadata back with the object
+   when reading."
+  ([w tag o]
+   (write-with-meta w tag o (fn [^Writer w o] (.writeList w o))))
+  ([^Writer w tag o write-fn]
+   (let [m (meta o)]
+     (do
+       (.writeTag w tag 2)
+       (write-fn w o)
+       (if m
+         (.writeObject w m)
+         (.writeNull w))))))
+
+(defn- read-meta [^Reader rdr]
+  (some->> rdr
+           .readObject
+           (into {})))
+
+(defn read-with-meta
+  "Reads an object from the reader that was written via write-with-meta.  If the object was written
+   with metadata the metadata will be associated on the object returned."
+  [^Reader rdr build-fn]
+  (let [o (build-fn (.readObject rdr))
+        m (read-meta rdr)]
+    (cond-> o
+      m (with-meta m))))
+
+(defn write-record
+  "Same as write-with-meta, but with Clojure record support.  The type of the record will
+   be preserved."
+  [^Writer w tag rec]
+  (let [m (meta rec)]
+    (.writeTag w tag 3)
+    (.writeObject w (record-map-constructor-name rec) true)
+    (write-map w rec)
+    (if m
+      (.writeObject w m)
+      (.writeNull w))))
+
+(defn read-record
+  "Same as read-with-meta, but with Clojure record support.  The type of the record will
+   be preserved."
+  ([^Reader rdr]
+   (read-record rdr nil))
+  ([^Reader rdr add-fn]
+   (let [builder (-> (.readObject rdr) resolve deref)
+         build-map (.readObject rdr)
+         m (read-meta rdr)]
+     (cond-> (builder build-map)
+       m (with-meta m)
+       add-fn add-fn))))
+
+(defn- create-cached-node-handler
+  ([clazz
+    tag
+    tag-for-cached]
+   {:class clazz
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (let [node-id (:id o)]
+                  (if (@d/*node-id->node-cache* node-id)
+                    (do
+                      (.writeTag w tag-for-cached 1)
+                      (.writeInt w node-id))
+                    (do
+                      (d/cache-node o)
+                      (write-record w tag o))))))
+    :readers {tag-for-cached
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (d/node-id->node (.readObject rdr))))
+              tag
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (-> rdr
+                      read-record
+                      d/cache-node)))}})
+  ([clazz
+    tag
+    tag-for-cached
+    remove-node-expr-fn
+    add-node-expr-fn]
+   {:class clazz
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (let [node-id (:id o)]
+                  (if (@d/*node-id->node-cache* node-id)
+                    (do
+                      (.writeTag w tag-for-cached 1)
+                      (.writeInt w node-id))
+                    (do
+                      (d/cache-node o)
+                      (write-record w tag (remove-node-expr-fn o)))))))
+    :readers {tag-for-cached
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (d/node-id->node (.readObject rdr))))
+              tag
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (-> rdr
+                      (read-record add-node-expr-fn)
+                      d/cache-node)))}}))
+
+(def handlers
+  "A structure tying together the custom Fressian write and read handlers used
+   by FressianSessionSerializer's."
+  {"java/class"
+   {:class Class
+    :writer (reify WriteHandler
+              (write [_ w c]
+                (.writeTag w "java/class" 1)
+                (.writeObject w (symbol (.getName ^Class c)) true)))
+    :readers {"java/class"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (resolve (.readObject rdr))))}}
+
+   "clj/set"
+   {:class clojure.lang.APersistentSet
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (write-with-meta w "clj/set" o)))
+    :readers {"clj/set"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (read-with-meta rdr set)))}}
+
+   "clj/vector"
+   {:class clojure.lang.APersistentVector
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (write-with-meta w "clj/vector" o)))
+    :readers {"clj/vector"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (read-with-meta rdr vec)))}}
+
+   "clj/list"
+   {:class clojure.lang.PersistentList
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (write-with-meta w "clj/list" o)))
+    :readers {"clj/list"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (read-with-meta rdr #(apply list %))))}}
+
+   "clj/aseq"
+   {:class clojure.lang.ASeq
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (write-with-meta w "clj/aseq" o)))
+    :readers {"clj/aseq"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (read-with-meta rdr sequence)))}}
+
+   "clj/lazyseq"
+   {:class clojure.lang.LazySeq
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (write-with-meta w "clj/lazyseq" o)))
+    :readers {"clj/lazyseq"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (read-with-meta rdr sequence)))}}
+
+   "clj/map"
+   {:class clojure.lang.APersistentMap
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (write-with-meta w "clj/map" o write-map)))
+    :readers {"clj/map"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (read-with-meta rdr #(into {} %))))}}
+   
+   "clj/treeset"
+   {:class clojure.lang.PersistentTreeSet
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (let [cname (d/sorted-comparator-name o)]
+                  (.writeTag w "clj/treeset" 2)
+                  (if cname
+                    (.writeObject w cname true)
+                    (.writeNull w))
+                  (.writeList w o))))
+    :readers {"clj/treeset"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (let [c (some-> rdr .readObject resolve deref)]
+                    (d/seq->sorted-set (.readObject rdr) c))))}}
+
+   "clj/treemap"
+   {:class clojure.lang.PersistentTreeMap
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (let [cname (d/sorted-comparator-name o)]
+                  (.writeTag w "clj/treemap" 2)
+                  (if cname
+                    (.writeObject w cname true)
+                    (.writeNull w))
+                  (write-map w o))))
+    :readers {"clj/treemap"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (let [c (some-> rdr .readObject resolve deref)]
+                    (d/seq->sorted-map (.readObject rdr) c))))}}
+
+   "clj/mapentry"
+   {:class clojure.lang.MapEntry
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (.writeTag w "clj/mapentry" 2)
+                (.writeObject w (key o) true)
+                (.writeObject w (val o))))
+    :readers {"clj/mapentry"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (d/create-map-entry (.readObject rdr)
+                                      (.readObject rdr))))}}
+
+   ;; Have to redefine both Symbol and IRecord to support metadata as well
+   ;; as identity-based caching for the IRecord case.
+
+   "clj/sym"
+   {:class clojure.lang.Symbol
+    :writer (reify WriteHandler
+              (write [_ w o]
+                ;; Mostly copied from private fres/write-named, except the metadata part.
+                (.writeTag w "clj/sym" 3)
+                (.writeObject w (namespace o) true)
+                (.writeObject w (name o) true)
+                (if-let [m (meta o)]
+                  (.writeObject w m)
+                  (.writeNull w))))
+    :readers {"clj/sym"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (let [s (symbol (.readObject rdr) (.readObject rdr))
+                        m (read-meta rdr)]
+                    (cond-> s
+                      m (with-meta m)))))}}
+
+   "clj/record"
+   {:class clojure.lang.IRecord
+    ;; Write a record a single time per object reference to that record.  The record is then "cached"
+    ;; with the IdentityHashMap `d/*clj-record-holder*`.  If another reference to this record instance
+    ;; is encountered later, only the "index" of the record in the map will be written.
+    :writer (reify WriteHandler
+              (write [_ w rec]
+                (if-let [idx (d/clj-record-fact->idx rec)]
+                  (do
+                    (.writeTag w "clj/recordidx" 1)
+                    (.writeInt w idx))
+                  (do
+                    (write-record w "clj/record" rec)
+                    (d/clj-record-holder-add-fact-idx! rec)))))
+    ;; When reading the first time a reference to a record instance is found, the entire record will
+    ;; need to be constructed.  It is then put into indexed cache.  If more references to this record
+    ;; instance are encountered later, they will be in the form of a numeric index into this cache.
+    ;; This is guaranteed by the semantics of the corresponding WriteHandler.
+    :readers {"clj/recordidx"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (d/clj-record-idx->fact (.readInt rdr))))
+              "clj/record"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (-> rdr
+                      read-record
+                      d/clj-record-holder-add-fact!)))}}
+
+   "clara/productionnode"
+   (create-cached-node-handler ProductionNode
+                               "clara/productionnode"
+                               "clara/productionnodeid"
+                               #(assoc % :rhs nil)
+                               d/add-rhs-fn)
+
+   "clara/querynode"
+   (create-cached-node-handler QueryNode
+                               "clara/querynode"
+                               "clara/querynodeid")
+
+   "clara/alphanode"
+   {:class AlphaNode
+    ;; The writer and reader here work similar to the IRecord implementation.  The only
+    ;; difference is that the record needs to be written with out the compiled clj
+    ;; function on it.  This is due to clj functions not having any convenient format
+    ;; for serialization.  The function is restored by re-eval'ing the function based on
+    ;; its originating code form at read-time.
+    :writer (reify WriteHandler
+              (write [_ w o]
+                (if-let [idx (d/clj-record-fact->idx o)]
+                  (do
+                    (.writeTag w "clara/alphanodeid" 1)
+                    (.writeInt w idx))
+                  (do
+                    (write-record w "clara/alphanode" (assoc o :activation nil))
+                    (d/clj-record-holder-add-fact-idx! o)))))
+    :readers {"clara/alphanodeid"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (d/clj-record-idx->fact (.readObject rdr))))
+              "clara/alphanode"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (-> rdr
+                      (read-record d/add-alpha-fn)
+                      d/clj-record-holder-add-fact!)))}}
+
+   "clara/rootjoinnode"
+   (create-cached-node-handler RootJoinNode
+                               "clara/rootjoinnode"
+                               "clara/rootjoinnodeid")
+
+   "clara/hashjoinnode"
+   (create-cached-node-handler HashJoinNode
+                               "clara/hashjoinnode"
+                               "clara/hashjoinnodeid")
+
+   "clara/exprjoinnode"
+   (create-cached-node-handler ExpressionJoinNode
+                               "clara/exprjoinnode"
+                               "clara/exprjoinnodeid"
+                               #(assoc % :join-filter-fn nil)
+                               d/add-join-filter-fn)
+
+   "clara/negationnode"
+   (create-cached-node-handler NegationNode
+                               "clara/negationnode"
+                               "clara/negationnodeid")
+
+   "clara/negationwjoinnode"
+   (create-cached-node-handler NegationWithJoinFilterNode
+                               "clara/negationwjoinnode"
+                               "clara/negationwjoinnodeid"
+                               #(assoc % :join-filter-fn nil)
+                               d/add-join-filter-fn)
+
+   "clara/testnode"
+   (create-cached-node-handler TestNode
+                               "clara/testnode"
+                               "clara/testnodeid"
+                               #(assoc % :test nil)
+                               d/add-test-fn)
+
+   "clara/accumnode"
+   (create-cached-node-handler AccumulateNode
+                               "clara/accumnode"
+                               "clara/accumnodeid"
+                               #(assoc % :accumulator nil)
+                               d/add-accumulator)
+
+   "clara/accumwjoinnode"
+   (create-cached-node-handler AccumulateWithJoinFilterNode
+                               "clara/accumwjoinnode"
+                               "clara/accumwjoinnodeid"
+                               #(assoc % :accumulator nil :join-filter-fn nil)
+                               (comp d/add-accumulator d/add-join-filter-fn))
+
+   "clara/ruleorderactivation"
+   {:class RuleOrderedActivation
+    :writer (reify WriteHandler
+              (write [_ w c]
+                (.writeTag w "clara/ruleorderactivation" 4)
+                (.writeObject w (.-node-id ^RuleOrderedActivation c) true)
+                (.writeObject w (.-token ^RuleOrderedActivation c))
+                (.writeObject w (.-activation ^RuleOrderedActivation c))
+                (.writeInt w (.-rule-load-order ^RuleOrderedActivation c))))
+    :readers {"clara/ruleorderactivation"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (mem/->RuleOrderedActivation (.readObject rdr)
+                                               (.readObject rdr)
+                                               (.readObject rdr)
+                                               (.readObject rdr))))}}
+
+   "clara/memidx"
+   {:class MemIdx
+    :writer (reify WriteHandler
+              (write [_ w c]
+                (.writeTag w "clara/memidx" 1)
+                (.writeInt w (:idx c))))
+    :readers {"clara/memidx"
+              (reify ReadHandler
+                (read [_ rdr tag component-count]
+                  (d/find-mem-idx (.readObject rdr))))}}})
+
+(def write-handlers
+  "All Fressian write handlers used by FressianSessionSerializer's."
+  (into fres/clojure-write-handlers
+        (map (fn [[tag {clazz :class wtr :writer}]]
+               [clazz {tag wtr}]))
+        handlers))
+
+(def read-handlers
+  "All Fressian read handlers used by FressianSessionSerializer's."
+    (->> handlers
+       vals
+       (into fres/clojure-read-handlers
+             (mapcat :readers))))
+
+(def write-handler-lookup
+  (-> write-handlers
+      fres/associative-lookup
+      fres/inheritance-lookup))
+
+(def read-handler-lookup
+  (fres/associative-lookup read-handlers))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Session serializer.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defrecord FressianSessionSerializer [in-stream out-stream]
+  d/ISessionSerializer
+  (serialize [_ session opts]
+    (let [{:keys [rulebase memory]} (eng/components session)
+          record-holder (IdentityHashMap.)
+          do-serialize
+          (fn [sources]
+            (with-open [^FressianWriter wtr
+                        (fres/create-writer out-stream :handlers write-handler-lookup)]
+              (binding [d/*node-id->node-cache* (volatile! {})
+                        d/*clj-record-holder* record-holder]
+                (doseq [s sources] (fres/write-object wtr s)))))]
+
+      ;; In this case there is nothing to do with memory, so just serialize immediately.
+      (if (:rulebase-only? opts)
+        (do-serialize [rulebase])
+
+        ;; Otherwise memory needs to have facts extracted to return.
+        (let [{:keys [memory indexed-facts]} (d/indexed-session-memory-state memory)
+              sources (if (:with-rulebase? opts)
+                        [rulebase memory]
+                        [memory])]
+
+          (do-serialize sources)
+          
+          ;; Return the facts needing to be serialized still.
+          indexed-facts))))
+
+  (deserialize [_ mem-facts opts]
+    (with-open [^FressianReader rdr (fres/create-reader in-stream :handlers read-handler-lookup)]
+      (let [{:keys [rulebase-only? base-rulebase]} opts
+
+            record-holder (ArrayList.)
+            ;; The rulebase should either be given from the base-session or found in
+            ;; the restored session-state.
+            rulebase (or (and (not rulebase-only?) base-rulebase)
+                         (binding [d/*node-id->node-cache* (volatile! {})
+                                   d/*clj-record-holder* record-holder
+                                   d/*compile-expr-fn* (memoize (fn [id expr] (com/try-eval expr)))]
+                           (fres/read-object rdr)))]
+
+        (if rulebase-only?
+          rulebase
+          (d/assemble-restored-session rulebase
+                                       (binding [d/*clj-record-holder* record-holder
+                                                 d/*mem-facts* mem-facts]
+                                         (fres/read-object rdr))
+                                       opts))))))
+
+(s/defn create-session-serializer
+  "Creates an instance of FressianSessionSerializer which implements d/ISessionSerializer by using
+   Fressian serialization for the session structures.
+   
+   In the one arity case, takes either an input stream or an output stream.  This arity is intended for
+   creating a Fressian serializer instance that will only be used for serialization or deserialization,
+   but not both.  e.g. This is often convenient if serialization and deserialization are not done from
+   the same process.  If it is to be used for serialization, then the stream given should be an output
+   stream.  If it is to be used for deserialization, then the stream to be given should be an
+   input stream.
+
+   In the two arity case, takes an input stream and an output stream.  These will be used for
+   deserialization and serialization within the created Fressian serializer instance, respectively.
+
+   Note!  Currently this only supports the clara.rules.memory.PersistentLocalMemory implementation
+          of memory."
+  ([in-or-out-stream :- (s/pred (some-fn #(instance? InputStream %)
+                                         #(instance? OutputStream %))
+                                "java.io.InputStream or java.io.OutputStream")]
+   (if (instance? InputStream in-or-out-stream)
+     (create-session-serializer in-or-out-stream nil)
+     (create-session-serializer nil in-or-out-stream)))
+
+  ([in-stream :- (s/maybe InputStream)
+    out-stream :- (s/maybe OutputStream)]
+   (->FressianSessionSerializer in-stream out-stream)))

--- a/src/test/clojure/clara/durability_rules.clj
+++ b/src/test/clojure/clara/durability_rules.clj
@@ -1,0 +1,64 @@
+(ns clara.durability-rules
+  (:require [clara.rules :refer :all]
+            [clara.rules.accumulators :as acc]
+            [clara.rules.testfacts :refer :all])
+  (:import [clara.rules.testfacts
+            Temperature
+            WindSpeed
+            Cold
+            Hot
+            TemperatureHistory]))
+
+(defrecord Threshold [v])
+(defrecord TempsUnderThreshold [ts])
+
+(defrule find-cold
+  "Rule with no joins"
+  [Temperature (= ?t temperature) (< temperature 30)]
+  =>
+  (insert! (->Cold ?t)))
+
+(defrule find-hot
+  "Rule using NegationWithJoinFilterNode"
+  [Temperature (= ?t temperature)]
+  [:not [Cold (>= temperature ?t)]]
+  =>
+  (insert! (->Hot ?t)))
+
+(defrecord UnpairedWindSpeed [ws])
+
+(defrule find-wind-speeds-without-temp
+  "Rule using NegationNode"
+  [?w <- WindSpeed (= ?loc location)]
+  [:not [Temperature (= ?loc location)]]
+  =>
+  (insert! (->UnpairedWindSpeed ?w)))
+
+(defrule find-temps
+  "Rule using AccumulateNode and TestNode"
+  [?ts <- (acc/all) :from [Temperature]]
+  [:test (not-empty ?ts)]
+  =>
+  (insert! (->TemperatureHistory (mapv :temperature ?ts))))
+
+(defrule find-temps-under-threshold
+  "Rule using AccumulateWithJoinFilterNode"
+  [Threshold (= ?v v)]
+  [?ts <- (acc/all) :from [Temperature (< temperature ?v)]]
+  =>
+  (insert! (->TempsUnderThreshold ?ts)))
+
+(defquery unpaired-wind-speed []
+  [?ws <- UnpairedWindSpeed])
+
+(defquery cold-temp []
+  [?c <- Cold])
+
+(defquery hot-temp []
+  [?h <- Hot])
+
+(defquery temp-his []
+  [?his <- TemperatureHistory])
+
+(defquery temps-under-thresh []
+  [?tut <- TempsUnderThreshold])

--- a/src/test/clojure/clara/test_durability.clj
+++ b/src/test/clojure/clara/test_durability.clj
@@ -1,163 +1,257 @@
 (ns clara.test-durability
   (:require [clara.rules :refer :all]
             [clara.rules.dsl :as dsl]
+            [clara.rules.engine :as eng]
             [clara.rules.durability :as d]
+            [clara.rules.durability.fressian :as df]
+            [clara.durability-rules :as dr]
             [clara.rules.accumulators :as acc]
             [clara.rules.testfacts :refer :all]
-            [clojure.test :refer :all]
-            schema.test)
-  (:import [clara.rules.testfacts Temperature Cold]))
+            [schema.test :as st]
+            [clojure.java.io :as jio]
+            [clojure.test :refer :all])
+  (:import [clara.rules.testfacts
+            Temperature]))
 
-(use-fixtures :once schema.test/validate-schemas)
+(use-fixtures :once st/validate-schemas)
 
-(defn- restore-session
-  "Wrapper for d/restore-session-state that validates the session can be serialized."
-  [session session-state]
-  (d/restore-session-state session (-> (pr-str session-state)
-                                       (read-string))))
+(defrecord LocalMemorySerializer [holder]
+  d/IWorkingMemorySerializer
+  (serialize-facts [_ fact-seq]
+    (reset! holder fact-seq))
+  (deserialize-facts [_]
+    @holder))
 
-(defn- has-fact? [token fact]
-  (some #{fact} (map first (:matches token))))
+(defn check-fact
+  "Helper for checking facts in durability-test."
+  [expected-fact fact]
 
-(deftest test-restore-simple-query
+  ;; Test equality first.  The tests need to be stricter than this, but if this isn't true nothing
+  ;; else will be.  This will give the best failure messages first too in the more obvious non-equal
+  ;; cases.
+  (when (is (= expected-fact fact)
+            "The expected and actual must be equal")
+    
+    (or (identical? expected-fact fact)
+        (and (is (= (coll? expected-fact)
+                    (coll? fact))
+                 (str "not identical? with expected should mean both are collections" \newline
+                      "expected fact: " expected-fact \newline
+                      "fact: " fact \newline))
 
-  (let [cold-query (dsl/parse-query [] [[?t <- Temperature (< temperature 20)]])
+             (is (= (count expected-fact)
+                    (count fact))
+                 (str "not identical? with expected should mean both are the"
+                      " same size collections" \newline
+                      "expected fact: " expected-fact \newline
+                      "fact: " fact \newline))
 
-        session (-> (mk-session [cold-query])
+             ;; Not handling collection types not being used right now in the test.
+             ;; This is only using the rules from clara.durability-rules.
+             ;; If more sophisticated aggregates are used in join bindings, fact bindings,
+             ;; or accumulated results in these tests case, the testing here will have to
+             ;; be made more robust to show it.
+             (cond
+               (sequential? expected-fact)
+               (and (is (sequential? fact)
+                        (str "expected is sequential?" \newline
+                             "expected fact: " expected-fact \newline
+                             "fact: " fact \newline))
+                    (mapv check-fact
+                          expected-fact
+                          fact))
 
-                    (insert (->Temperature 10 "MCI"))
-                    (fire-rules))
+               (set? expected-fact)
+               (and (is (set? fact)
+                        "expected is set?")
+                    (every? #(is (identical? (expected-fact %) %)
+                                 (str "the fact from one set must be found in the"
+                                      " expected set and be identical? to it" \newline
+                                      "expected fact: " expected-fact \newline
+                                      "fact: " fact \newline))
+                            fact))
 
-        session-state (d/session-state session)
+               :else
+               (is false
+                   (str "Must find a matching comparison with the expected."
+                        "  Most of the time this means the facts should be identical?" \newline
+                        "expected fact: " expected-fact \newline
+                        "fact: " fact \newline)))))))
 
-        restored-session (-> (mk-session [cold-query])
-                             (restore-session session-state))]
+(defn durability-test
+  "Test runner to run different implementations of d/ISessionSerializer."
+  [serde-type]
+  (let [s (mk-session 'clara.durability-rules)
 
-    (is (= [{:?t (->Temperature 10 "MCI")}]
-           (query session cold-query)))
+        ;; Testing identity relationships on the IWorkingMemorySerializer facts received to serialize.
+        ;; So this is a little weird, but we want to know the exact object identity of even these
+        ;; "primitive" values.
+        mci "MCI"
+        lax "LAX"
+        san "SAN"
+        chi "CHI"
+        irk "IRK"
+        ten 10
+        twenty 20 
+        fifty 50
+        forty 40
+        thirty 30
+        thresh50 (dr/->Threshold fifty)
+        temp50 (->Temperature fifty mci)
+        temp40 (->Temperature forty lax)
+        temp30 (->Temperature thirty san)
+        temp20 (->Temperature twenty chi)
+        ws50 (->WindSpeed fifty mci)
+        ws40 (->WindSpeed forty lax)
+        ws10 (->WindSpeed ten irk)
+        fired (-> s
+                  (insert thresh50
+                          temp50
+                          temp40
+                          temp30
+                          temp20
+                          ws50
+                          ws40
+                          ws10)
+                  fire-rules)
 
-    (is (= [{:?t (->Temperature 10 "MCI")}]
-           (query restored-session cold-query)))))
+        unpaired-res (query fired dr/unpaired-wind-speed)
+        cold-res (query fired dr/cold-temp)
+        hot-res (query fired dr/hot-temp)
+        temp-his-res (query fired dr/temp-his)
+        temps-under-thresh-res (query fired dr/temps-under-thresh)
 
+        create-serializer (fn [stream]
+                            ;; Currently only one.
+                            (condp = serde-type
+                              :fressian (df/create-session-serializer stream)))
 
-(deftest test-restore-unfired-activation
-  (let [rule-output (atom nil)
-        cold-rule (dsl/parse-rule [[Temperature (< temperature 20)]]
-                                  (reset! rule-output ?__token__))
+        rulebase-baos (java.io.ByteArrayOutputStream.)
+        rulebase-serializer (create-serializer rulebase-baos)
 
-        session-state (-> (mk-session [cold-rule])
-                          (insert (->Temperature 10 "MCI"))
-                          (d/session-state))]
+        session-baos (java.io.ByteArrayOutputStream.)
+        session-serializer (create-serializer session-baos)
 
-    ;; Rule not yet fired, so the output should be nil.
-    (is (nil? @rule-output))
+        holder (atom [])
+        mem-serializer (->LocalMemorySerializer holder)]
 
-    ;; Restore the session and run the rule.
-    (-> (mk-session [cold-rule])
-        (restore-session session-state)
-        (fire-rules))
+    ;; Serialize the data.  Store the rulebase seperately.  This is likely to be the most common usage.
+    
+    (d/serialize-rulebase fired
+                          rulebase-serializer)
+    (d/serialize-session-state fired
+                               session-serializer
+                               mem-serializer)
 
-    (is (has-fact? @rule-output (->Temperature 10 "MCI")))))
+    (let [rulebase-data (.toByteArray rulebase-baos)
+          session-data (.toByteArray session-baos)
 
+          rulebase-bais (java.io.ByteArrayInputStream. rulebase-data)
+          session-bais (java.io.ByteArrayInputStream. session-data)
+          rulebase-serializer (create-serializer rulebase-bais)
+          session-serializer (create-serializer session-bais)
 
-(deftest test-restore-fired-activation
-  (let [rule-output (atom nil)
-        cold-rule (dsl/parse-rule [[Temperature (< temperature 20)]]
-                                  (reset! rule-output ?__token__))
-
-        session-state (-> (mk-session [cold-rule])
-                          (insert (->Temperature 10 "MCI"))
-                          (fire-rules)
-                          (d/session-state))]
-
-    ;; Rule fired previously, so the output should be in place.
-    (is (has-fact? @rule-output (->Temperature 10 "MCI")))
-
-    ;; Clear the output and restore the session. It should already be activated,
-    ;; so the output is not updated again.
-    (reset! rule-output nil)
-
-    (-> (mk-session [cold-rule])
-        (restore-session session-state)
-        (fire-rules))
-
-    (is (nil? @rule-output))))
-
-(deftest test-restore-accum-result
-  (let [lowest-temp (acc/min :temperature :returns-fact true)
-        coldest-query (dsl/parse-query [] [[?t <- lowest-temp from [Temperature]]])
-
-        session (-> (mk-session [coldest-query])
-                    (insert (->Temperature 15 "MCI")
-                            (->Temperature 10 "MCI")
-                            (->Temperature 80 "MCI"))
-                    (fire-rules))
-
-        session-state (d/session-state session)
-
-        restored-session (-> (mk-session [coldest-query])
-                             (restore-session session-state))]
-
-    ;; Accumulator returns the lowest value.
-    (is (= #{{:?t (->Temperature 10 "MCI")}}
-           (set (query session coldest-query))
-           (set (query restored-session coldest-query))))))
-
-(deftest test-restore-truth-maintenance
-  (let [cold-rule (dsl/parse-rule [[Temperature (< temperature 20) (= ?temp temperature)]]
-                                  (insert! (->Cold ?temp)))
-
-        cold-query (dsl/parse-query [] [[?cold <- Cold]])
-
-        empty-session (mk-session [cold-rule cold-query])
-
-        persist-and-restore (fn [session]
-                              (restore-session empty-session
-                                               (d/session-state session)))
-
-        cold-result {:?cold (->Cold 10)}]
-
-    (let [session (-> empty-session
-                      (insert (->Temperature 10 "MCI"))
-                      (fire-rules))
-
-          session-state (d/session-state session)
+          restored-rulebase (d/deserialize-rulebase rulebase-serializer)
+          restored (d/deserialize-session-state session-serializer
+                                                mem-serializer
+                                                {:base-rulebase restored-rulebase})
           
-          restored-session (-> empty-session
-                               (restore-session session-state))]
+          r-unpaired-res (query restored dr/unpaired-wind-speed)
+          r-cold-res (query restored dr/cold-temp)
+          r-hot-res (query restored dr/hot-temp)
+          r-temp-his-res (query restored dr/temp-his)
+          r-temps-under-thresh-res (query restored dr/temps-under-thresh)
 
-      (is (= [{:?cold (->Cold 10)}]
-             (query restored-session cold-query))
-          "Query for a Cold fact from the restored session.")
+          facts @(:holder mem-serializer)]
 
-      ;; Ensure the retraction propagates and removes our inserted item.
-      (is (= []
-             (query (retract restored-session (->Temperature 10 "MCI")) cold-query))
-          "Validate that the restored session doesn't contain a Cold fact after
-         the Temperature fact that inserted it in the original session is retracted."))
+      (testing "Ensure the queries return same before and after serialization"
+        (is (= (frequencies [{:?ws (dr/->UnpairedWindSpeed ws10)}])
+               (frequencies unpaired-res)
+               (frequencies r-unpaired-res)))
 
-    (let [session (-> empty-session
-                      (insert (->Temperature 10 "MCI"))
-                      (insert (->Temperature 10 "MCI"))
-                      (fire-rules))
+        (is (= (frequencies [{:?c (->Cold 20)}])
+               (frequencies cold-res)
+               (frequencies r-cold-res)))
 
-          restored-session (persist-and-restore session)]
+        (is (= (frequencies [{:?h (->Hot 50)}
+                             {:?h (->Hot 40)}
+                             {:?h (->Hot 30)}])
+               (frequencies hot-res)
+               (frequencies r-hot-res)))
 
-      (is (= [cold-result cold-result]
-             (query restored-session cold-query))
-          "Two duplicate Cold facts should be restored from the persisted session when there
-           are two duplicate Temperature facts.")
+        (is (= (frequencies [{:?his (->TemperatureHistory [50 40 30 20])}])
+               (frequencies temp-his-res)
+               (frequencies r-temp-his-res)))
 
-      (is (= (query (retract restored-session (->Temperature 10 "MCI"))
-                    cold-query)
-             [cold-result])
-          "When there are two duplicate Cold facts from two separate Temperature
-           facts and one Temperature fact is retracted we should still have 1 Cold fact.")
+        (is (= (frequencies [{:?tut (dr/->TempsUnderThreshold [temp40 temp30 temp20])}])
+               (frequencies temps-under-thresh-res)
+               (frequencies r-temps-under-thresh-res))))
 
-      (is (= (query (-> restored-session
-                        (retract (->Temperature 10 "MCI"))
-                        (retract (->Temperature 10 "MCI")))
-                    cold-query)
-             [])
-          "When two duplicate Cold facts are inserted from two duplicate Temperature facts,
-           and both Temperature facts are retracted, no Cold facts should remain."))))
+      (testing "metadata is preserved on rulebase nodes"
+        (let [node-with-meta (->> s
+                                  eng/components
+                                  :rulebase
+                                  :id-to-node
+                                  vals
+                                  (filter #(meta %))
+                                  first)
+              restored-node-with-meta (-> restored-rulebase
+                                          :id-to-node
+                                          (get (:id node-with-meta)))]
+          (is (= (meta node-with-meta) (meta restored-node-with-meta)))))
+
+      (testing (str "facts given to serialize-facts of IWorkingMemorySerializer"
+                    " from ISessionSerializer have identity relationships"
+                    " retained and accumulated values present.")
+        ;; Unfortunately what seems like the best way to test this right now is to just manually
+        ;; write out the whole expectation.  This is brittle, but hopefully doesn't change
+        ;; that often.
+        (let [cold20 (-> cold-res first :?c)
+              unpaired-ws10 (-> unpaired-res first :?ws)
+              temp-his (-> temp-his-res first :?his)
+              temps-under-thresh (-> temps-under-thresh-res first :?tut)
+              [hot30 hot40 hot50] (->> hot-res (map :?h) (sort-by :temperature))
+
+              ;; All of these facts must have an identical? relationship (same object references)
+              ;; as the actual facts being tested against.
+              expected-facts [temp50
+                              temp40
+                              temp30
+                              temp20
+                              [temp50 temp40 temp30 temp20]
+                              mci
+                              lax
+                              san
+                              chi
+                              twenty
+                              cold20
+                              unpaired-ws10
+                              temp-his
+                              ws50
+                              ws40
+                              ws10
+                              irk
+                              fifty
+                              forty
+                              thirty
+                              thresh50
+                              temps-under-thresh
+                              hot40
+                              hot30
+                              hot50
+                              [temp40 temp30 temp20]]]
+          
+          (is (= (count expected-facts)
+                 (count facts))
+              (str "expected facts:" \newline
+                   (vec expected-facts) \newline
+                   "actual facts:" \newline
+                   (vec facts)))
+          
+          (doseq [i (range (count expected-facts))
+                  :let [expected-fact (nth expected-facts i)
+                        fact (nth facts i)]]
+            (check-fact expected-fact fact)))))))
+ 
+(deftest test-durability-fressian-serde
+  (durability-test :fressian))


### PR DESCRIPTION
This is a first pass at the work described in #198 .

There are two protocols in `clara.rules.durability`

* ISessionSerializer
 * Responsible for serializing and deserializing the session (and rulebase) structure of the rule sessions
 * This one will likely rarely, if ever, need to be customized by a consumer.  It has to be tightly coupled to the implementation of a rule session memory, which should generally be advised against
 * Clara is going to provide a default implementation via Fressian in `clara.rules.durability.fressian` namespace
   * This namespace requires a dependency on `org.clojure/data.fressian` see https://github.com/clojure/data.fressian
    * This is an "optional" dependency and not included in Clara's explicit dependencies (it's only a `:dev` dependency for testing).

* IWorkingMemorySerializer
 * Responsible for serializing and deserializing the "consumer-defined" facts that are contained within working memory
 * This one is expected to be implemented by consumers in a way that makes the most sense for serializing their domain model objects
 * We could provide some helpful defaults here in the future (I hope to have some additions here soon).
    * Many of the serialization functions exposed in `clara.rules.durability` can be useful concepts or helpful to implement the IWorkingMemorySerializer.  The Fressian handlers defined in `clara.rules.durability.fressian` have been written to be able to serialize/deserialize most Clojure persistent data structures, metadata, and preserve record identity relationships among each other or where they are used in different aggregates.  This is useful to implementations of IWorkingMemorySerializer as well, if Fressian is in consideration.

The approach to serialization is documented quite a bit within the `clara.rules.durability` and `clara.rules.durability.fressian` namespaces.
   
The old functions from this `clara.rules.durability` namespace have been removed since they were not actively maintained and were out of sync with the evolution of Clara's memory and the engine over time.  The motivations behind this new approach to durability can be found in #198 .

As the `clara.rules.durability` namespace doc string states, this namespace should be considered experimental still.  The API itself is subject to change and even more importantly, rule sessions or rulebases serialized in one version of Clara are not guaranteed to be able to be deserialized in another version.
