### PR TITLE
Added listening capability to alpha-activate and alpha-retract in alpha network

### DIFF
--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -329,25 +329,30 @@
 (defrecord AlphaNode [env children activation]
   IAlphaActivate
   (alpha-activate [node facts memory transport listener]
-    (send-elements
-     transport
-     memory
-     listener
-     children
-     (for [fact facts
-           :let [bindings (activation fact env)] :when bindings] ; FIXME: add env.
-       (->Element fact bindings))))
+    (let [fact-binding-pairs (for [fact facts
+                                   :let [bindings (activation fact env)] :when bindings] ; FIXME: add env.
+                               [fact bindings])]
+      (l/alpha-activate! listener node (map first fact-binding-pairs))
+      (send-elements
+        transport
+        memory
+        listener
+        children
+        (for [[fact bindings] fact-binding-pairs]
+          (->Element fact bindings)))))
 
   (alpha-retract [node facts memory transport listener]
-
-    (retract-elements
-     transport
-     memory
-     listener
-     children
-     (for [fact facts
-           :let [bindings (activation fact env)] :when bindings] ; FIXME: add env.
-       (->Element fact bindings)))))
+    (let [fact-binding-pairs (for [fact facts
+                                   :let [bindings (activation fact env)] :when bindings] ; FIXME: add env.
+                               [fact bindings])]
+      (l/alpha-retract! listener node (map first fact-binding-pairs))
+      (retract-elements
+        transport
+        memory
+        listener
+        children
+        (for [[fact bindings] fact-binding-pairs]
+          (->Element fact bindings))))))
 
 (defrecord RootJoinNode [id condition children binding-keys]
   ILeftActivate

--- a/src/main/clojure/clara/rules/listener.cljc
+++ b/src/main/clojure/clara/rules/listener.cljc
@@ -12,8 +12,10 @@
   (right-activate! [listener node elements])
   (right-retract! [listener node elements])
   (insert-facts! [listener facts])
+  (alpha-activate! [listener node facts])
   (insert-facts-logical! [listener node token facts])
   (retract-facts! [listener facts])
+  (alpha-retract! [listener node facts])
   (retract-facts-logical! [listener node token facts])
   (add-accum-reduced! [listener node join-bindings result fact-bindings])
   (remove-accum-reduced! [listener node join-bindings fact-bindings])
@@ -35,9 +37,13 @@
     listener)
   (insert-facts! [listener facts]
     listener)
+  (alpha-activate! [listener node facts]
+    listener)
   (insert-facts-logical! [listener node token facts]
     listener)
   (retract-facts! [listener facts]
+    listener)
+  (alpha-retract! [listener node facts]
     listener)
   (retract-facts-logical! [listener node token facts]
     listener)
@@ -82,6 +88,10 @@
   (insert-facts! [listener facts]
     (doseq [child children]
       (insert-facts! child facts)))
+  
+  (alpha-activate! [listener node facts]
+    (doseq [child children]
+      (alpha-activate! child node facts)))
 
   (insert-facts-logical! [listener node token facts]
     (doseq [child children]
@@ -90,6 +100,10 @@
   (retract-facts! [listener facts]
     (doseq [child children]
       (retract-facts! child facts)))
+  
+  (alpha-retract! [listener node facts]
+    (doseq [child children]
+      (alpha-retract! child node facts)))
 
   (retract-facts-logical! [listener node token facts]
     (doseq [child children]

--- a/src/main/clojure/clara/tools/tracing.clj
+++ b/src/main/clojure/clara/tools/tracing.clj
@@ -28,12 +28,18 @@
 
   (insert-facts! [listener facts]
     (append-trace listener {:type :add-facts :facts facts}))
+  
+  (alpha-activate! [listener node facts]
+    (append-trace listener {:type :alpha-activate :facts facts}))
 
   (insert-facts-logical! [listener node token facts]
     (append-trace listener {:type :add-facts-logical :token token :facts facts}))
 
   (retract-facts! [listener facts]
     (append-trace listener {:type :retract-facts :facts facts}))
+  
+  (alpha-retract! [listener node facts]
+    (append-trace listener {:type :alpha-retract :facts facts}))
 
   (retract-facts-logical! [listener node token facts]
     (append-trace listener {:type :retract-facts-logical :token token :facts facts}))

--- a/src/test/clojure/clara/tools/test_tracing.clj
+++ b/src/test/clojure/clara/tools/test_tracing.clj
@@ -36,7 +36,7 @@
                     (fire-rules))]
 
     ;; Ensure expected events occur in order.
-    (is (= [:add-facts :right-activate :left-activate :add-activations]
+    (is (= [:add-facts :alpha-activate :right-activate :left-activate :add-activations]
            (map :type (t/get-trace session))))))
 
 (deftest test-rhs-retraction-trace
@@ -50,9 +50,9 @@
                     (insert (->Temperature 10 "MCI"))
                     (fire-rules))]
     (is (= (map :type (t/get-trace session))
-           [:add-facts :right-activate :left-activate
-            :add-facts :right-activate :left-activate
-            :add-activations :retract-facts :right-retract :left-retract])
+           [:add-facts :alpha-activate :right-activate :left-activate
+            :add-facts :alpha-activate :right-activate :left-activate
+            :add-activations :retract-facts :alpha-retract :right-retract :left-retract])
         "Validate that a retract! call in the RHS side of a rule appears in the trace
          before the :right-retract")))
         
@@ -66,9 +66,9 @@
                     (insert (->Temperature 10 "MCI"))
                     (insert (->Temperature 80 "MCI")))]
 
-    (is (= [:add-facts :accum-reduced :left-activate
-            :add-facts :accum-reduced :left-retract
-            :left-activate :add-facts :accum-reduced]
+    (is (= [:add-facts :alpha-activate :accum-reduced :left-activate
+            :add-facts :alpha-activate :accum-reduced :left-retract
+            :left-activate :add-facts :alpha-activate :accum-reduced]
 
            (map :type (t/get-trace session)))))
 
@@ -81,7 +81,7 @@
                       (insert (->Temperature 15 "MCI"))
                       fire-rules)]
 
-      (is (= [:add-facts :accum-reduced :left-retract :left-activate]
+      (is (= [:add-facts :alpha-activate :accum-reduced :left-retract :left-activate]
 
              (map :type (t/get-trace session)))))))
 
@@ -95,7 +95,7 @@
                     (fire-rules))]
 
     ;; Ensure expected events occur in order.
-    (is (= [:add-facts :right-activate :left-activate :add-activations :add-facts-logical]
+    (is (= [:add-facts :alpha-activate :right-activate :left-activate :add-activations :add-facts-logical]
            (map :type (t/get-trace session))))))
 
 (deftest test-insert-and-retract-trace
@@ -113,8 +113,8 @@
        session-trace (t/get-trace session)]
 
     ;; Ensure expected events occur in order.
-   (is (= [:add-facts :right-activate :left-activate :add-activations :add-facts-logical
-           :retract-facts :right-retract :left-retract :remove-activations :retract-facts-logical]
+   (is (= [:add-facts :alpha-activate :right-activate :left-activate :add-activations :add-facts-logical
+           :retract-facts :alpha-retract :right-retract :left-retract :remove-activations :retract-facts-logical]
           (map :type session-trace)))
 
    ;; Ensure only the expected fact was indicated as retracted.


### PR DESCRIPTION
Added a listening capability to alpha-activate and alpha-retract, so that we can listen to the facts added or retracted the alpha network. We need it internally to know which facts that were inserted or retracted, matched some of the alpha nodes.
Listener on insert-facts and retract-facts will not give me facts that are guaranteed to match something in the alpha network.
I am not appending the trace for alpha-activate and alpha-retract in tracing listener, as it will add redundant information from insert-facts and retract-facts.