### PR TITLE
Add listener calls to all nodes

### DIFF
--- a/src/test/clojure/clara/tools/test_tracing.clj
+++ b/src/test/clojure/clara/tools/test_tracing.clj
@@ -66,9 +66,10 @@
                     (insert (->Temperature 10 "MCI"))
                     (insert (->Temperature 80 "MCI")))]
 
-    (is (= [:add-facts :alpha-activate :accum-reduced :left-activate
-            :add-facts :alpha-activate :accum-reduced :left-retract
-            :left-activate :add-facts :alpha-activate :accum-reduced]
+    (is (= [:add-facts :alpha-activate :right-activate :accum-reduced
+            :left-activate :add-facts :alpha-activate :right-activate
+            :accum-reduced :left-retract :left-activate :add-facts
+            :alpha-activate :right-activate :accum-reduced]
 
            (map :type (t/get-trace session)))))
 
@@ -81,7 +82,7 @@
                       (insert (->Temperature 15 "MCI"))
                       fire-rules)]
 
-      (is (= [:add-facts :alpha-activate :accum-reduced :left-retract :left-activate]
+      (is (= [:add-facts :alpha-activate :right-activate :accum-reduced :left-retract :left-activate]
 
              (map :type (t/get-trace session)))))))
 


### PR DESCRIPTION
I've found tracing to be quite useful, even with a limited subset of nodes making the listener calls.  I've ended up adding tracing calls in my local branch before to solve this.  Note that since the node is available to the listener calls, either the listener or processing on data collected by the listener can filter on the things that are relevant to a particular use-case.  I think there is some future work to be done here in tracing; for example, I'd like to have a helper function that gets only the tracing for descendants of alpha nodes for a particular type.  The first step is to have all the information available though.  This could break any listeners that depend on only a subset of nodes having tracing, but I think the correct way to do that sort of logic is for the listener to dispatch on the node given.  The information in the session object (e.g. alpha-roots and id-to-node) should supply any necessary information to a consumer for such dispatching logic.