### PR TITLE
AccumulateNode right-retract with previous right-activate may fail

### DIFF
--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -969,10 +969,16 @@
                                         (do-accumulate accumulator retracted))
                                       ::not-reduced)
 
+                  ;; It is possible that either the retracted or previous reduced are ::not-reduced
+                  ;; at this point if there are no matching tokens.  has-matches? indicates this.  If
+                  ;; this is the case, there are no converted values to calculate.  However, memory still
+                  ;; will be updated since the facts left after this retraction still need to be stored
+                  ;; for later possible activations.
                   retracted-converted (when (and (some? retracted-reduced)
                                                  (not= ::not-reduced retracted-reduced))
                                         (convert-return-fn retracted-reduced))
-                  previous-converted (when (some? previous-reduced)
+                  previous-converted (when (and (some? previous-reduced)
+                                                (not= ::not-reduced previous-reduced))
                                        (convert-return-fn previous-reduced))]]
       
       (if all-retracted?


### PR DESCRIPTION
The following throws an exception

```clj
(let [checked-all (assoc (acc/all)
                           ;; Add an explicit :convert-return-fn to be sure that this
                           ;; is only called with a valid reduced value.
                           :convert-return-fn
                           (fn [x]
                             (if (coll? x)
                               x
                               (is false
                                   (str "An invalid value was given to the :convert-return-fn: " x)))))
        q (dsl/parse-query [] [[Cold]
                               [?hs <- checked-all :from [Hot]]])

        hot (->Hot 50)]

    (is (empty? (-> (mk-session [q] :cache false)
                    (insert hot)
                    (retract hot)
                    fire-rules
                    (query q)
                    set))))
```

It should pass.


This was introduced in https://github.com/rbrush/clara-rules/commit/127a28314f067860e7a3748130b6318aca283d73 .

I made an optimization here that if an AccumulateNode had `right-activate`s, but no `left-activate` that the reduced value would not be calculated until later when/if a `left-activate` ever occurred.  In this way, it made the accumulating behavior of the AccumulateNode lazier in when it was evaluated.

When the node had not calculated a reduced value yet, a placeholder of `:clara.rules.engine/not-reduced` was placed into memory to be specially mark the node's reduced value as "lazy"/"unrealized".

This value is not a valid value to pass to the `:convert-return-fn` of the accumulator, but the check for it was missed.

The changes here include a test for this case, along with a fix.