### PR TITLE
Fix clara.rules.engine/flush-rhs-insertions! to remove duplicate call…

### DIFF
--- a/src/main/clojure/clara/rules/engine.cljc
+++ b/src/main/clojure/clara/rules/engine.cljc
@@ -233,11 +233,12 @@
     ;; Update the count so the rule engine will know when we have normalized.
     (swap! insertions + (count facts))
 
+    (when listener
+      (l/retract-facts! listener facts))
+
     (doseq [[alpha-roots fact-group] (get-alphas-fn facts)
             root alpha-roots]
-
-      (when listener
-        (l/retract-facts! listener fact-group))
+      
       (alpha-retract root fact-group transient-memory transport listener))))
 
 (defn ^:private flush-insertions!


### PR DESCRIPTION
…s to clara.rules.listener/retract-facts!

Currently a fact retracted in a rule RHS will show up in a tracing listener once per matching alpha node, while a fact externally retracted will show up once.  [1]  I introduced this inconsistency in https://github.com/rbrush/clara-rules/pull/173/files This pull request makes the two retraction types consistent by making a single RHS retraction listener call.  If a user wants information on activation of particular alpha nodes that information is directly available now after https://github.com/rbrush/clara-rules/pull/220


1. https://github.com/rbrush/clara-rules/blob/0.13.0-RC2/src/main/clojure/clara/rules/engine.cljc#L1513